### PR TITLE
Fix missing third mode argument on open() with O_CREAT

### DIFF
--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -105,7 +105,7 @@ rdp_allocate_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_memor
 	strcat(path, "/");
 	strcat(path, shared_memory->name);
 
-	fd = open(path, O_CREAT | O_RDWR);
+	fd = open(path, O_CREAT | O_RDWR, 00600);
 	if (fd < 0) {
 		weston_log("%s: Failed to open \"%s\" with error: %s\n",
 			__func__, path, strerror(errno));


### PR DESCRIPTION
This failed to build onto Ubuntu 20.04.