### PR TITLE
add timeline logging for performance investigation

### DIFF
--- a/libweston/compositor.c
+++ b/libweston/compositor.c
@@ -2879,6 +2879,9 @@ output_repaint_timer_arm(struct weston_compositor *compositor)
 
 		msec_to_this = timespec_sub_to_msec(&output->next_repaint,
 						    &now);
+		TL_POINT(compositor, "core_repaint_timer_arm_output", TLP_OUTPUT(output),
+			 TLP_MSEC(&msec_to_this),
+ 			 TLP_END);
 		if (!any_should_repaint || msec_to_this < msec_to_next)
 			msec_to_next = msec_to_this;
 
@@ -2896,6 +2899,9 @@ output_repaint_timer_arm(struct weston_compositor *compositor)
 	 */
 	if (msec_to_next < 1)
 		msec_to_next = 1;
+
+	TL_POINT(compositor, "core_repaint_timer_arm",
+		TLP_MSEC(&msec_to_next), TLP_END);
 
 	wl_event_source_timer_update(compositor->repaint_timer, msec_to_next);
 }
@@ -2990,6 +2996,7 @@ weston_output_finish_frame(struct weston_output *output,
 	int32_t refresh_nsec;
 	struct timespec now;
 	struct timespec vblank_monotonic;
+	struct timespec next_present_monotonic;
 	int64_t msec_rel;
 
 	assert(output->repaint_status == REPAINT_AWAITING_COMPLETION);
@@ -3023,7 +3030,6 @@ weston_output_finish_frame(struct weston_output *output,
 	timespec_add_msec(&output->next_repaint, &output->next_repaint,
 			  -compositor->repaint_msec);
 	msec_rel = timespec_sub_to_msec(&output->next_repaint, &now);
-
 	if (msec_rel < -1000 || msec_rel > 1000) {
 		static bool warned;
 
@@ -3048,7 +3054,16 @@ weston_output_finish_frame(struct weston_output *output,
 		}
 	}
 
+	weston_compositor_read_presentation_clock(compositor, &now);
 out:
+	next_present_monotonic = convert_presentation_time_now(compositor,
+							 &output->next_repaint, &now,
+							 CLOCK_MONOTONIC);
+	TL_POINT(compositor, "core_repaint_finished_next_repaint", TLP_OUTPUT(output),
+		 TLP_MSEC(&msec_rel),
+		 TLP_NEXT_PRESENT(&next_present_monotonic),
+		 TLP_END);
+
 	output->repaint_status = REPAINT_SCHEDULED;
 	output_repaint_timer_arm(compositor);
 }
@@ -3062,6 +3077,7 @@ idle_repaint(void *data)
 	assert(output->repaint_status == REPAINT_BEGIN_FROM_IDLE);
 	output->repaint_status = REPAINT_AWAITING_COMPLETION;
 	output->idle_repaint_source = NULL;
+	TL_POINT(output->compositor, "core_repaint_start_loop", TLP_OUTPUT(output), TLP_END);
 	ret = output->start_repaint_loop(output);
 	if (ret != 0)
 		weston_output_schedule_repaint_reset(output);

--- a/libweston/compositor.c
+++ b/libweston/compositor.c
@@ -3030,6 +3030,7 @@ weston_output_finish_frame(struct weston_output *output,
 	timespec_add_msec(&output->next_repaint, &output->next_repaint,
 			  -compositor->repaint_msec);
 	msec_rel = timespec_sub_to_msec(&output->next_repaint, &now);
+
 	if (msec_rel < -1000 || msec_rel > 1000) {
 		static bool warned;
 

--- a/libweston/timeline.c
+++ b/libweston/timeline.c
@@ -341,6 +341,27 @@ emit_gpu_timestamp(struct timeline_emit_context *ctx, void *obj)
 	return 1;
 }
 
+static int
+emit_msec(struct timeline_emit_context *ctx, void *obj)
+{
+	int64_t *i = obj;
+
+	fprintf(ctx->cur, "\"msec\":%" PRId64 "", *i);
+
+	return 1;
+}
+
+static int
+emit_present_timestamp(struct timeline_emit_context *ctx, void *obj)
+{
+	struct timespec *ts = obj;
+
+	fprintf(ctx->cur, "\"next_present\":[%" PRId64 ", %ld]",
+		(int64_t)ts->tv_sec, ts->tv_nsec);
+
+	return 1;
+}
+
 static struct weston_timeline_subscription_object *
 weston_timeline_get_subscription_object(struct weston_log_subscription *sub,
 		void *object)
@@ -388,6 +409,8 @@ static const type_func type_dispatch[] = {
 	[TLT_SURFACE] = emit_weston_surface,
 	[TLT_VBLANK] = emit_vblank_timestamp,
 	[TLT_GPU] = emit_gpu_timestamp,
+	[TLT_MSEC] = emit_msec,
+	[TLT_PRESENT] = emit_present_timestamp,
 };
 
 /** Disseminates the message to all subscriptions of the scope \c

--- a/libweston/timeline.h
+++ b/libweston/timeline.h
@@ -39,6 +39,8 @@ enum timeline_type {
 	TLT_SURFACE,
 	TLT_VBLANK,
 	TLT_GPU,
+	TLT_MSEC,
+	TLT_PRESENT,
 };
 
 /** Timeline subscription created for each subscription
@@ -83,6 +85,8 @@ struct weston_timeline_subscription_object {
 #define TLP_SURFACE(s) TLT_SURFACE, TYPEVERIFY(struct weston_surface *, (s))
 #define TLP_VBLANK(t) TLT_VBLANK, TYPEVERIFY(const struct timespec *, (t))
 #define TLP_GPU(t) TLT_GPU, TYPEVERIFY(const struct timespec *, (t))
+#define TLP_MSEC(i) TLT_MSEC, TYPEVERIFY(const int64_t *, (i))
+#define TLP_NEXT_PRESENT(t) TLT_PRESENT, TYPEVERIFY(const struct timespec *, (t))
 
 /** This macro is used to add timeline points.
  *


### PR DESCRIPTION
add timeline logging for performance investigation

- add timeline logging with wait msec and next present time.