### PR TITLE
support two finger scroll on precision touch pad

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -1492,6 +1492,7 @@ xf_mouseEvent(rdpInput *input, UINT16 flags, UINT16 x, UINT16 y)
 
 	if (flags & PTR_FLAGS_WHEEL) {
 		struct weston_pointer_axis_event weston_event;
+		int ivalue;
 		double value;
 
 		/* DEFAULT_AXIS_STEP_DISTANCE is stolen from compositor-x11.c
@@ -1500,19 +1501,27 @@ xf_mouseEvent(rdpInput *input, UINT16 flags, UINT16 x, UINT16 y)
 		 *
 		 * https://blogs.msdn.microsoft.com/oldnewthing/20130123-00/?p=5473 explains the 120 value
 		 */
-		value = -(flags & 0xff) / 120.0;
 		if (flags & PTR_FLAGS_WHEEL_NEGATIVE)
-			value = -value;
+			ivalue = (int)((char)(flags & 0xff));
+		else
+			ivalue = (flags & 0xff);
+		peerContext->accumWheelRotation += ivalue;
+		if (abs(peerContext->accumWheelRotation) >= 12) {
+			/* multiply -1 is due to directional swap to match Windows direction of scroll. */
+			value = (double)(peerContext->accumWheelRotation / 12) * -1;
 
-		weston_event.axis = WL_POINTER_AXIS_VERTICAL_SCROLL;
-		weston_event.value = DEFAULT_AXIS_STEP_DISTANCE * value;
-		weston_event.discrete = (int)value;
-		weston_event.has_discrete = true;
+			weston_event.axis = WL_POINTER_AXIS_VERTICAL_SCROLL;
+			weston_event.value = DEFAULT_AXIS_STEP_DISTANCE * value;
+			weston_event.discrete = (int)value;
+			weston_event.has_discrete = true;
 
-		weston_compositor_get_time(&time);
+			weston_compositor_get_time(&time);
 
-		notify_axis(peerContext->item.seat, &time, &weston_event);
-		need_frame = true;
+			notify_axis(peerContext->item.seat, &time, &weston_event);
+			need_frame = true;
+
+			peerContext->accumWheelRotation %= 12;
+		}
 	}
 
 	if (need_frame)

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -270,6 +270,7 @@ struct rdp_peer_context {
 
 	bool button_state[5];
 	char key_state[0xff/8]; // one bit per key.
+	int accumWheelRotation;
 
 	// RAIL support
 	HANDLE vcm;


### PR DESCRIPTION
support two finger scroll on precision touch pad

when precision touch pad is used, the value reported is not 120 (WHEEL_DELTA) increment as MSDN noted, but it come with much smaller values in higher frequency, thus there is accumulation is needed.

https://github.com/microsoft/wslg/issues/42