### PR TITLE
RDP Backend Performance Fix

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -184,7 +184,6 @@ struct rdp_backend {
 	uint32_t debug_desktop_scaling_factor; /* must be between 100 to 500 */
 
 	int rdp_monitor_refresh_rate;
-	int rdp_repaint_delay_ms;
 
 #if defined(HAVE_FREERDP_RDPAPPLIST_H) || defined(HAVE_FREERDP_GFXREDIR_H)
 	void *libFreeRDPServer;
@@ -222,7 +221,7 @@ struct rdp_peers_item {
 
 struct rdp_monitor_mode {
 	rdpMonitor monitorDef; // in client coordinate.
-	int scale; // per monitor DPI scaling. 
+	int scale; // per monitor DPI scaling.
 	float clientScale;
 	pixman_rectangle32_t rectWeston; // in weston coordinate.
 };
@@ -247,7 +246,7 @@ struct rdp_output {
 	uint32_t index;
 
 	struct wl_list peers;
-	struct wl_list link; // rdp_backend::output_list 
+	struct wl_list link; // rdp_backend::output_list
 };
 
 typedef struct _rdp_audio_block_info {
@@ -527,7 +526,7 @@ to_weston_x(RdpPeerContext *peer, int32_t x)
 }
 
 /* TO BE REMOVED */
-static inline int32_t 
+static inline int32_t
 to_weston_y(RdpPeerContext *peer, int32_t y)
 {
 	return y - peer->regionClientHeads.extents.y1;
@@ -616,7 +615,7 @@ to_client_coordinate(RdpPeerContext *peerContext, struct weston_output *output, 
 		to_client_scale_only(peerContext, output, scale, &sx, &sy);
 		if (width && height)
 			to_client_scale_only(peerContext, output, scale, width, height);
-		/* translate x/y to offset from this output on client space. */ 
+		/* translate x/y to offset from this output on client space. */
 		sx += head->monitorMode.monitorDef.x;
 		sy += head->monitorMode.monitorDef.y;
 		rdp_debug_verbose(b, "%s: (x:%d, y:%d) -> (sx:%d, sy:%d) at head:%s\n",


### PR DESCRIPTION
This fixes the issue where Weston wasn't presenting at the rate
it was expected to. In particular, the RDP backend would always
take 16ms to complete a frame after being sent to the host. Upon
frame completion, Weston would calculat the next frame to present
based on the monitor refresh and target 9ms ahead of that. At 64hz
this ended up having Weston compositor wait for 9ms for the next
frame and that 9ms would add up to the RDP monitor 16ms simulated
VSYNC, resulting in an effective presentation rate of 1/25ms = 40fps.

The VSYNC emulation is now improved and the RDP backend keeps the
frame completion within the total expected refresh, so at 64hz
the frame are kept a total of 16ms apart.

Also updated the VSYNC emulation code to adapt the RDP monitor
refresh to what is specified through the environment variable
WESTON_RDP_MONITOR_REFRESH_RATE.