### PR TITLE
support window z order sync with client

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -83,7 +83,7 @@ struct weston_rdprail_shell_api {
 
 	/** Activate a window.
 	 */
-	void (*request_window_activate)(struct weston_surface *surface, struct weston_seat *seat);
+	void (*request_window_activate)(void *shell_context, struct weston_seat *seat, struct weston_surface *surface);
 
 	/** Close a window.
 	 */
@@ -160,6 +160,11 @@ struct weston_rdprail_api {
 	/** Get primary output
 	 */
 	struct weston_output *(*get_primary_output)(void *rdp_backend);
+
+	/** Update window zorder
+	 */
+	void (*notify_window_zorder_change)(struct weston_compositor *compositor,
+		struct weston_surface *surface);
 };
 
 static inline const struct weston_rdprail_api *

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -1453,7 +1453,7 @@ rdp_validate_button_state(RdpPeerContext *peerContext, bool pressed, uint32_t* b
 	uint32_t index = *button - BTN_LEFT;
 	assert(index < ARRAY_LENGTH(peerContext->button_state));
 	if (pressed == peerContext->button_state[index]) {
-		rdp_debug(b, "%s: inconsistent button state button:%d (index:%d) pressed:%d\n",
+		rdp_debug_verbose(b, "%s: inconsistent button state button:%d (index:%d) pressed:%d\n",
 			__func__, *button, index, pressed);
 		/* ignore button input */
 		*button = 0;
@@ -1634,7 +1634,7 @@ xf_input_keyboard_event(rdpInput *input, UINT16 flags, UINT16 code)
 	uint32_t scan_code, vk_code, full_code;
 	enum wl_keyboard_key_state keyState;
 	RdpPeerContext *peerContext = (RdpPeerContext *)input->context;
-	/*struct rdp_backend *b = peerContext->rdpBackend;*/
+	struct rdp_backend *b = peerContext->rdpBackend;
 
 	int notify = 0;
 	struct timespec time;
@@ -1659,8 +1659,11 @@ xf_input_keyboard_event(rdpInput *input, UINT16 flags, UINT16 code)
 		assert(vk_code <= 0xFF);
 		if (keyState == WL_KEYBOARD_KEY_STATE_RELEASED) {
 			/* Ignore release if key is not previously pressed. */
-			if ((peerContext->key_state[vk_code>>3] & (1<<(vk_code&0x7))) == 0)
+			if ((peerContext->key_state[vk_code>>3] & (1<<(vk_code&0x7))) == 0) {
+				rdp_debug_verbose(b, "%s: inconsistent key state vk_code:%x\n",
+					__func__, vk_code);
 				goto exit;
+			}
 			peerContext->key_state[vk_code>>3] &= ~(1<<(vk_code&0x7));
 		} else {
 			peerContext->key_state[vk_code>>3] |= (1<<(vk_code&0x7));

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -181,6 +181,8 @@ struct rdp_backend {
 
 	struct wl_listener create_window_listener;
 
+	bool enable_window_zorder_sync;
+
 	bool enable_hi_dpi_support;
 	bool enable_fractional_hi_dpi_support;
 	uint32_t debug_desktop_scaling_factor; /* must be between 100 to 500 */
@@ -308,6 +310,9 @@ struct rdp_peer_context {
 	struct wl_list loop_event_source_list;
 	struct wl_listener idle_listener;
 	struct wl_listener wake_listener;
+
+	bool is_window_zorder_dirty;
+	struct weston_surface *active_surface;
 
 	// Multiple monitor support (monitor topology)
 	pixman_region32_t regionClientHeads;


### PR DESCRIPTION
Support window z order sync with client.

https://github.com/microsoft/wslg/issues/10

This utilize RDP's "Actively Monitored Desktop" protocol to send Linux side window z order to Windows client.

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/7ed2eff1-c565-42ad-8e0d-9bd9b858421f
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/600d7335-92be-4ec1-9de2-f135003c5742

There is known limitation when the foreground Linux app is closed and the next window in z order is Windows application, the focus will not move to that Windows application, but will move to the Linux app which is highest next to the closing application. Follow up PR is planned to address this issue.

