### PR TITLE
Fix scroll rotation to work both with standard and precision wheels

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -110,7 +110,6 @@
 #include "shared/timespec-util.h"
 
 #define MAX_FREERDP_FDS 32
-#define DEFAULT_AXIS_STEP_DISTANCE 10
 #define RDP_MODE_FREQ 60 * 1000
 #define RDP_MAX_MONITOR 16 // RDP max monitors.
 
@@ -273,7 +272,8 @@ struct rdp_peer_context {
 
 	bool button_state[5];
 	char key_state[0xff/8]; // one bit per key.
-	int accumWheelRotation;
+	int accumWheelRotationPrecise;
+	int accumWheelRotationDiscrete;
 
 	// RAIL support
 	HANDLE vcm;


### PR DESCRIPTION
Fix wheel increments such that we send a movement update to our
Wayland clients every 12 wheel increments for smmooth scrolling
on high precision wheels or pads, but only bump the discrete wheel
tick every 120 wheel increments so it aligns properly with standard
wheel which always do +120/-120 increment at every wheel notch.