### PR TITLE
fix shell crash with android studio 4.2

### DIFF
--- a/desktop-shell/shell.c
+++ b/desktop-shell/shell.c
@@ -2780,8 +2780,11 @@ desktop_surface_set_parent(struct weston_desktop_surface *desktop_surface,
 
 	if (parent) {
 		shsurf_parent = weston_desktop_surface_get_user_data(parent);
-		wl_list_insert(shsurf_parent->children_list.prev,
-			       &shsurf->children_link);
+		if (shsurf_parent)
+			wl_list_insert(shsurf_parent->children_list.prev,
+				       &shsurf->children_link);
+		else
+			wl_list_init(&shsurf->children_link);
 	} else {
 		wl_list_init(&shsurf->children_link);
 	}

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -2427,14 +2427,20 @@ desktop_surface_set_parent(struct weston_desktop_surface *desktop_surface,
 
 	if (parent) {
 		shsurf_parent = weston_desktop_surface_get_user_data(parent);
-		wl_list_insert(shsurf_parent->children_list.prev,
-			       &shsurf->children_link);
-		/* libweston-desktop doesn't establish parent/child relationship
-		   with weston_desktop_api shell_desktop_api.set_parent call,
-		   thus calling weston_desktop_surface_get_parent won't work,
-		   so shell need to track by itself. This also means child's
-		   geometry won't be adjusted to relative to parent. */
-		shsurf->parent = shsurf_parent;
+		if (shsurf_parent) {
+			wl_list_insert(shsurf_parent->children_list.prev,
+				       &shsurf->children_link);
+			/* libweston-desktop doesn't establish parent/child relationship
+			   with weston_desktop_api shell_desktop_api.set_parent call,
+			   thus calling weston_desktop_surface_get_parent won't work,
+			   so shell need to track by itself. This also means child's
+			   geometry won't be adjusted to relative to parent. */
+			shsurf->parent = shsurf_parent;
+		} else {
+			weston_log("RDP shell: parent is not toplevel surface\n");
+			wl_list_init(&shsurf->children_link);
+			shsurf->parent = NULL;
+		}
 	} else {
 		wl_list_init(&shsurf->children_link);
 		shsurf->parent = NULL;


### PR DESCRIPTION
This issue happens with android studio 4.2 in below step.

1) start android studio 4.2
2) "help" -> "about".
3) click upper-right 'x' (close button) while about window is still open. (if doesn't crash, click 'x' a few more times).

this is because android studio 4.2 is putting "about" window, which is "override_redirect", as parent of "confirm exit" dialog.