### PR TITLE
add wl_subsurface to z order list

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -217,6 +217,7 @@ struct weston_surface_rail_state {
 	bool forceUpdateWindowState;
 	bool error;
 	bool isUpdatePending;
+	bool isFirstUpdateDone;
 	void *get_label;
 	int taskbarButton;
 


### PR DESCRIPTION
RDP client requires child window to be included in Z order list, even such parent-child relationship is already expressed by WINDOW_STATE_ORDER.ownerWindowId. 

In our implementation, wl_subsurface is considered as child window, and it's reported to RDP client with its top level window as its owner. 

This change let wl_subsurface to be included in Z order list sent to client.

https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/2d36758d-3fb5-4823-8c4b-9b81a9c8ff3e
https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdperp/7ed2eff1-c565-42ad-8e0d-9bd9b858421f

This addresses the issue reported by https://github.com/microsoft/wslg/issues/10#issuecomment-839713308

