### PR TITLE
fix crash at walking window for z order list

### DIFF
--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -2454,7 +2454,12 @@ rdp_insert_window_zorder_array(struct weston_view *view, UINT32 *windowIdArray, 
 	}
 
 	/* insert itself as parent (which is below sub-surfaces in z order) */
-	if (rail_state->isWindowCreated &&
+	/* because z order is taken from compositor's scene-graph, it's possible
+	   there is surface hasn't been associated with rail_state, so check it.
+	   and if window is not remoted to client side, or minimized (or going to be
+	   minimized), those won't included in z order list. */
+	if (rail_state &&
+	    rail_state->isWindowCreated &&
 	    !rail_state->is_minimized &&
 	    !rail_state->is_minimized_requested) {
 		if (iCurrent >= WindowIdArraySize) {


### PR DESCRIPTION
fix crash at walking window for z order list

For z order, surface list is taken from compositor's scene-graph, thus it's possible there is surface hasn't been associated with backend_state (rail_state), so validate it before accessing it. And if window is not remoted to client side, or minimized (or going to be minimized), those won't be included in z order list to sent to RDP client.