### PR TITLE
fix android emulator window doesn't move and crash at minimize

### DIFF
--- a/libweston-desktop/xwayland.c
+++ b/libweston-desktop/xwayland.c
@@ -376,6 +376,29 @@ set_window_geometry(struct weston_desktop_xwayland_surface *surface,
 }
 
 static void
+set_position(struct weston_desktop_xwayland_surface *surface,
+	     int x, int y, int width, int height)
+{
+	if (surface->state == XWAYLAND) {
+		/* For XWAYLAND surface, here directly set view position,
+		   just like set_xwayland() when view is associated. */
+		if (surface->view)
+			weston_view_set_position(surface->view, x, y);
+	} else {
+		/* TODO what to do these? need a way to move shell surface! */
+	}
+#ifdef WM_DEBUG
+	weston_log("%s: %s window (%p) move to (%d,%d)\n",
+		   __func__, 
+		   (surface->state == XWAYLAND) ? "XWAYLAND" : \
+		       (surface->state == TOPLEVEL) ? "TOPLEVEL" : \
+		       (surface->state == MAXIMIZED) ? "MAXIMIZED" : \
+		       (surface->state == FULLSCREEN) ? "FULLSCREEN" : "UNKNOWN",
+		   surface, x, y);
+#endif
+}
+
+static void
 set_maximized(struct weston_desktop_xwayland_surface *surface)
 {
 	weston_desktop_xwayland_surface_change_state(surface, MAXIMIZED, NULL,
@@ -413,6 +436,7 @@ static const struct weston_desktop_xwayland_interface weston_desktop_xwayland_in
 	.set_transient = set_transient,
 	.set_fullscreen = set_fullscreen,
 	.set_xwayland = set_xwayland,
+	.set_position = set_position,
 	.move = move,
 	.resize = resize,
 	.set_title = set_title,

--- a/xwayland/xwayland-internal-interface.h
+++ b/xwayland/xwayland-internal-interface.h
@@ -48,6 +48,8 @@ struct weston_desktop_xwayland_interface {
 			       struct weston_output *output);
 	void (*set_xwayland)(struct weston_desktop_xwayland_surface *shsurf,
 			     int x, int y);
+	void (*set_position)(struct weston_desktop_xwayland_surface *shsurf,
+			     int x, int y, int width, int height);
 	int (*move)(struct weston_desktop_xwayland_surface *shsurf,
 		    struct weston_pointer *pointer);
 	int (*resize)(struct weston_desktop_xwayland_surface *shsurf,

--- a/xwayland/xwayland.h
+++ b/xwayland/xwayland.h
@@ -129,6 +129,7 @@ struct weston_wm {
 		xcb_atom_t		 net_wm_window_type_combo;
 		xcb_atom_t		 net_wm_window_type_dnd;
 		xcb_atom_t		 net_wm_window_type_normal;
+		xcb_atom_t		 kde_net_wm_window_type_override;
 		xcb_atom_t		 net_wm_moveresize;
 		xcb_atom_t		 net_supporting_wm_check;
 		xcb_atom_t		 net_supported;


### PR DESCRIPTION
This PR addresses with issue reported at https://github.com/microsoft/wslg/issues/139.

1: weston crash when minimize button at emulator window is pressed. (the window does not minimize, but same issue is observed with other Linux GUI platform as well).
2: (with frame window enabled) the emulator control window does not move along with the main emulator window when the main emulator window is dragged.
3: (with frame window disabled) the window shadow for main emulator window is still rendered.

Note: this does not fix the main emulator window is not movable when window frame is disabled, the issue is understood and the separate follow up PR will be made.