### PR TITLE
rdp-backend/rdprail-shell debug message rearrangement

### DIFF
--- a/libweston/backend-rdp/rdpdisp.c
+++ b/libweston/backend-rdp/rdpdisp.c
@@ -377,12 +377,12 @@ disp_monitor_validate_and_compute_layout(RdpPeerContext *peerCtx, struct rdp_mon
 		if (monitorMode[i].monitorDef.is_primary) {
 			/* count number of primary */
 			if (++primaryCount > 1) {
-				weston_log("%s: RDP client reported unexpected primary count (%d)\n",__func__, primaryCount);
+				rdp_debug_error(b, "%s: RDP client reported unexpected primary count (%d)\n",__func__, primaryCount);
 				return FALSE;
 			}
 			/* primary must be at (0,0) in client space */
 			if (monitorMode[i].monitorDef.x != 0 || monitorMode[i].monitorDef.y != 0) {
-				weston_log("%s: RDP client reported primary is not at (0,0) but (%d,%d).\n",
+				rdp_debug_error(b, "%s: RDP client reported primary is not at (0,0) but (%d,%d).\n",
 					__func__, monitorMode[i].monitorDef.x, monitorMode[i].monitorDef.y);
 				return FALSE;
 			}
@@ -463,7 +463,7 @@ disp_monitor_validate_and_compute_layout(RdpPeerContext *peerCtx, struct rdp_mon
 
 	if (isScalingUsed && (!isConnected_H && !isConnected_V)) {
 		/* scaling can't be supported in complex monitor placement */
-		weston_log("\nWARNING\nWARNING\nWARNING: Scaling is used, but can't be supported in complex monitor placement\nWARNING\nWARNING\n");
+		rdp_debug_error(b, "\nWARNING\nWARNING\nWARNING: Scaling is used, but can't be supported in complex monitor placement\nWARNING\nWARNING\n");
 		isScalingSupported = false;
 	}
 
@@ -537,7 +537,7 @@ disp_monitor_layout_change(DispServerContext* context, const DISPLAY_CONTROL_MON
 	assert(settings->HiDefRemoteApp);
 
 	if (displayControl->NumMonitors > RDP_MAX_MONITOR) {
-		weston_log("\nWARNING\nWARNING\nWARNING: client reports more monitors then expected:(%d)\nWARNING\nWARNING\n",
+		rdp_debug_error(b, "\nWARNING\nWARNING\nWARNING: client reports more monitors then expected:(%d)\nWARNING\nWARNING\n",
 			displayControl->NumMonitors);
 		return;
 	}
@@ -677,12 +677,12 @@ xf_peer_adjust_monitor_layout(freerdp_peer* client)
 	/* If not in RAIL mode, or RAIL-shell is not used, only signle mon is allowed */
 	if (!settings->HiDefRemoteApp || b->rdprail_shell_api == NULL) {
 	 	if (settings->MonitorCount > 1) {
-			weston_log("\nWARNING\nWARNING\nWARNING: multiple monitor is not supported in non HiDef RAIL mode\nWARNING\nWARNING\n");
+			rdp_debug_error(b, "\nWARNING\nWARNING\nWARNING: multiple monitor is not supported in non HiDef RAIL mode\nWARNING\nWARNING\n");
 			return FALSE;
 		}
 	}
 	if (settings->MonitorCount > RDP_MAX_MONITOR) {
-		weston_log("\nWARNING\nWARNING\nWARNING: client reports more monitors then expected:(%d)\nWARNING\nWARNING\n",
+		rdp_debug_error(b, "\nWARNING\nWARNING\nWARNING: client reports more monitors then expected:(%d)\nWARNING\nWARNING\n",
 			settings->MonitorCount);
 		return FALSE;
 	}

--- a/rdprail-shell/shell.h
+++ b/rdprail-shell/shell.h
@@ -49,6 +49,9 @@
 #define shell_rdp_debug(b, ...) \
 	if (b->debugLevel >= RDPRAIL_SHELL_DEBUG_LEVEL_INFO) \
 		shell_rdp_debug_print(b->debug, false, __VA_ARGS__)
+#define shell_rdp_debug_error(b, ...) \
+	if (b->debugLevel >= RDPRAIL_SHELL_DEBUG_LEVEL_ERR) \
+		shell_rdp_debug_print(b->debug, false, __VA_ARGS__)
 
 #define is_system_distro() (getenv("WSL2_VM_ID") != NULL)
 


### PR DESCRIPTION
This PR contains.

1: replace weston_log used in RDP backand and RDP-RAIL shell with RDP's own scope logging.
2: add state tracking to RDP clipboard to assist debugging.
3: support clearing WSLg side clipboard when client sends 0 format list (when client's clipboard is cleared).
4: disable optional RDP-RAIL shell key-bindings including zapping and rotate.
5: remove zoom functionality from RDP-RAIL shell key-bindings since it doesn't work and doesn't make sense with RAIL.