### PR TITLE
fix android emulator window is not movable when no frame

### DIFF
--- a/include/libweston-desktop/libweston-desktop.h
+++ b/include/libweston-desktop/libweston-desktop.h
@@ -117,6 +117,12 @@ struct weston_desktop_api {
 	 */
 	void (*set_xwayland_position)(struct weston_desktop_surface *surface,
 				      int32_t x, int32_t y, void *user_data);
+	/*
+	 * In contrast to above set_xwayland_position(), move_xwayland_position()
+	 * to be used to move window after mapped.
+	 */
+	void (*move_xwayland_position)(struct weston_desktop_surface *surface,
+				       int32_t x, int32_t y, void *user_data);
 };
 
 void

--- a/libweston-desktop/internal.h
+++ b/libweston-desktop/internal.h
@@ -91,6 +91,11 @@ weston_desktop_api_set_xwayland_position(struct weston_desktop *desktop,
 					 struct weston_desktop_surface *surface,
 					 int32_t x, int32_t y);
 
+void
+weston_desktop_api_move_xwayland_position(struct weston_desktop *desktop,
+					  struct weston_desktop_surface *surface,
+					  int32_t x, int32_t y);
+
 struct weston_desktop_seat *
 weston_desktop_seat_from_seat(struct weston_seat *wseat);
 

--- a/libweston-desktop/libweston-desktop.c
+++ b/libweston-desktop/libweston-desktop.c
@@ -262,3 +262,13 @@ weston_desktop_api_set_xwayland_position(struct weston_desktop *desktop,
 		desktop->api.set_xwayland_position(surface, x, y,
 						   desktop->user_data);
 }
+
+void
+weston_desktop_api_move_xwayland_position(struct weston_desktop *desktop,
+					  struct weston_desktop_surface *surface,
+					  int32_t x, int32_t y)
+{
+	if (desktop->api.move_xwayland_position != NULL)
+		desktop->api.move_xwayland_position(surface, x, y,
+						    desktop->user_data);
+}

--- a/xwayland/xwayland-internal-interface.h
+++ b/xwayland/xwayland-internal-interface.h
@@ -48,8 +48,8 @@ struct weston_desktop_xwayland_interface {
 			       struct weston_output *output);
 	void (*set_xwayland)(struct weston_desktop_xwayland_surface *shsurf,
 			     int x, int y);
-	void (*set_position)(struct weston_desktop_xwayland_surface *shsurf,
-			     int x, int y, int width, int height);
+	void (*move_position)(struct weston_desktop_xwayland_surface *shsurf,
+			     int x, int y);
 	int (*move)(struct weston_desktop_xwayland_surface *shsurf,
 		    struct weston_pointer *pointer);
 	int (*resize)(struct weston_desktop_xwayland_surface *shsurf,


### PR DESCRIPTION
fix android emulator window is not movable when no frame

This address the issue reported at https://github.com/microsoft/wslg/issues/139, and follow up PR to https://github.com/microsoft/weston-mirror/pull/14 since the first PR didn't address moving window without enabling window frame.

Basically this PR allows X11 app to move top level window by sending configure, which is not supported in weston. Previously the window movement was only possible by grab on frame window, or only before map.

There possibly concern on this behavior change, but in order to allow application like Android device emulator to behave properly, it needs to allow application initiated moving window.