### PR TITLE
enable font attribute fallback for international text in pango text rendering

### DIFF
--- a/shared/cairo-util.c
+++ b/shared/cairo-util.c
@@ -461,6 +461,7 @@ create_layout(cairo_t *cr, const char *title)
 {
 	PangoLayout *layout;
 	PangoFontDescription *desc;
+	PangoAttrList *attrs;
 
 	layout = pango_cairo_create_layout(cr);
 	if (title) {
@@ -468,6 +469,13 @@ create_layout(cairo_t *cr, const char *title)
 		desc = pango_font_description_from_string("Sans Bold 10");
 		pango_layout_set_font_description(layout, desc);
 		pango_font_description_free(desc);
+		/* enable fallback attribute */
+		attrs = pango_attr_list_new();
+		if (attrs) {
+			pango_attr_list_insert(attrs, pango_attr_fallback_new(true));
+			pango_layout_set_attributes(layout, attrs);
+			pango_attr_list_unref(attrs);
+		}
 	}
 	pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
 	pango_layout_set_alignment(layout, PANGO_ALIGN_LEFT);


### PR DESCRIPTION
enable font attribute fallback for international text in pango text rendering.

This PR addresses https://github.com/microsoft/wslg/issues/5, and with https://github.com/microsoft/wslg/pull/266 to allow system distro to load fonts from Windows.
