### PR TITLE
fix selection notifier never gets initialized if no seat at window manager initialization

### DIFF
--- a/xwayland/xwayland.h
+++ b/xwayland/xwayland.h
@@ -90,6 +90,7 @@ struct weston_wm {
 	int selection_property_set;
 	int flush_property_on_delete;
 	struct wl_listener selection_listener;
+	struct wl_listener seat_create_listener;
 
 	xcb_window_t dnd_window;
 	xcb_window_t dnd_owner;


### PR DESCRIPTION
This PR does below 4 things.

1: fix paste to X11 app doesn't work forever when weston_seat is not created at time of X window manager initialization, paste to X app never work as it never register the notification from data device.
2: fix access fault at debug message due to "source" being NULL.
3: allow retry to get data from client when client responded error.
4: add more debug logging and asserts.