### PR TITLE
fix display loop keep awake

### DIFF
--- a/libweston/backend-rdp/rdpdisp.c
+++ b/libweston/backend-rdp/rdpdisp.c
@@ -603,19 +603,32 @@ Exit:
 }
 
 struct disp_schedule_monitor_layout_change_data {
-	struct rdp_loop_event_source _base;
+	struct rdp_loop_event_source _base_event_source;
 	DispServerContext* context;
 	DISPLAY_CONTROL_MONITOR_LAYOUT_PDU displayControl;
 };
 
-static void
-disp_monitor_layout_change_callback(void* dataIn)
+static int
+disp_monitor_layout_change_callback(int fd, uint32_t mask, void* dataIn)
 {
 	struct disp_schedule_monitor_layout_change_data *data = (struct disp_schedule_monitor_layout_change_data *)dataIn;
 	DispServerContext* context = data->context;
-	wl_list_remove(&data->_base.link);
+	freerdp_peer *client = (freerdp_peer*)context->custom;
+	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
+
+	ASSERT_COMPOSITOR_THREAD(peerCtx->rdpBackend);
+
+	rdp_defer_rdp_task_done(peerCtx);
+	assert(data->_base_event_source.event_source);
+	wl_event_source_remove(data->_base_event_source.event_source);
+	pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
+	wl_list_remove(&data->_base_event_source.link);
+	pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);
+
 	disp_monitor_layout_change(context, &data->displayControl);
 	free(dataIn);
+
+	return 0;
 }
 
 UINT
@@ -643,16 +656,17 @@ disp_client_monitor_layout_change(DispServerContext* context, const DISPLAY_CONT
 	memcpy(data->displayControl.Monitors, displayControl->Monitors,
 		sizeof(DISPLAY_CONTROL_MONITOR_LAYOUT) * displayControl->NumMonitors);
 
-	pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex); \
-	wl_list_insert(&peerCtx->loop_event_source_list, &data->_base.link);
-	pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex); \
-	data->_base.event_source = rdp_defer_rdp_task_to_display_loop(peerCtx,
-					disp_monitor_layout_change_callback,
-					data);
-	if (!data->_base.event_source) {
-		pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex); \
-		wl_list_remove(&data->_base.link);
-		pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex); \
+	pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
+	wl_list_insert(&peerCtx->loop_event_source_list, &data->_base_event_source.link);
+	pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);
+	data->_base_event_source.event_source =
+		rdp_defer_rdp_task_to_display_loop(peerCtx,
+			disp_monitor_layout_change_callback,
+			data);
+	if (!data->_base_event_source.event_source) {
+		pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
+		wl_list_remove(&data->_base_event_source.link);
+		pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);
 		free(data);
 		return ERROR_INTERNAL_ERROR;  
 	}


### PR DESCRIPTION
fix display loop keep awake.

Previous implementation to defer the task from FreeRDP thread to Wayland display thread, it hook to Wayland idle loop and it rely on FreeRDP's virtual channel event to kick off display loop, but this was a bad choice as virtual channel event is tie to underlying MessageQueue and it only reset when the last message is unqueued, thus such usage put the situation event never reset as it signal without queuing message, and display loop keeps awake. This PR switch to own eventfd.

https://github.com/microsoft/wslg/issues/226