### PR TITLE
support Korean 101a and 103 keyboard

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -430,7 +430,7 @@ typedef struct rdp_peer_context RdpPeerContext;
 /* To enable rdp_debug message, add "--logger-scopes=rdp-backend". */
 
 // rdp.c
-void convert_rdp_keyboard_to_xkb_rule_names(UINT32 KeyboardType, UINT32 KeyboardLayout, struct xkb_rule_names *xkbRuleNames);
+void convert_rdp_keyboard_to_xkb_rule_names(UINT32 KeyboardType, UINT32 KeyboardSubType, UINT32 KeyboardLayout, struct xkb_rule_names *xkbRuleNames);
 struct rdp_head * rdp_head_create(struct weston_compositor *compositor, BOOL isPrimary, struct rdp_monitor_mode *monitorMode);
 void rdp_head_destroy(struct weston_compositor *compositor, struct rdp_head *head);
 

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -827,8 +827,10 @@ rail_client_LanguageImeInfo_callback(int fd, uint32_t mask, void *arg)
 	if (languageImeInfo->ProfileType == TF_PROFILETYPE_KEYBOARDLAYOUT) {
 		struct xkb_rule_names xkbRuleNames;
 		struct xkb_keymap *keymap = NULL;
+		settings->KeyboardLayout = languageImeInfo->KeyboardLayout;
 		convert_rdp_keyboard_to_xkb_rule_names(settings->KeyboardType,
-						       languageImeInfo->KeyboardLayout,
+						       settings->KeyboardSubType,
+						       settings->KeyboardLayout,
 						       &xkbRuleNames);
 		if (xkbRuleNames.layout) {
 			keymap = xkb_keymap_new_from_names(b->compositor->xkb_context,
@@ -837,6 +839,10 @@ rail_client_LanguageImeInfo_callback(int fd, uint32_t mask, void *arg)
 				weston_seat_update_keymap(peerCtx->item.seat, keymap);
 				xkb_keymap_unref(keymap);
 			}
+		}
+		if (!keymap) {
+			rdp_debug_error(b, "%s: Failed to switch to kbd_layout:0x%x kbd_type:0x%x kbd_subType:0x%x\n",
+				__func__, settings->KeyboardLayout, settings->KeyboardType, settings->KeyboardSubType);
 		}
 	}
 


### PR DESCRIPTION
This PR enabling the support for Korean 101a layout and 103 keyboard with special Hangul and Hanja key.

Note: Korean 101b and 101c layouts are not supported by this PR, this is because standard Xkb doesn't have configurations for these layout in Windows.

https://github.com/microsoft/wslg/issues/98
