### PR TITLE
let open fail if shared memory file already exists

### DIFF
--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -166,7 +166,7 @@ rdp_allocate_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_memor
 	strcat(path, "/");
 	strcat(path, shared_memory->name);
 
-	fd = open(path, O_CREAT | O_RDWR, 00600);
+	fd = open(path, O_CREAT | O_RDWR | O_EXCL, S_IWUSR | S_IRUSR);
 	if (fd < 0) {
 		rdp_debug_error(b, "%s: Failed to open \"%s\" with error: %s\n",
 			__func__, path, strerror(errno));


### PR DESCRIPTION
let open fail if shared memory file already exists for debugging

This is debugging code for track https://github.com/microsoft/wslg/issues/179.