### PR TITLE
Fix tabs and separate scroll axis accumulated ticks

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -276,8 +276,10 @@ struct rdp_peer_context {
 
 	bool button_state[5];
 	char key_state[0xff/8]; // one bit per key.
-	int accumWheelRotationPrecise;
-	int accumWheelRotationDiscrete;
+	int verticalAccumWheelRotationPrecise;
+	int verticalAccumWheelRotationDiscrete;
+	int horizontalAccumWheelRotationPrecise;
+	int horizontalAccumWheelRotationDiscrete;
 
 	// RAIL support
 	HANDLE vcm;


### PR DESCRIPTION
Follow up change after Steve pointed out some style issues I missed and that the scroll accumulated ticks should be per axis. This should complete this issue:

https://github.com/microsoft/wslg/issues/164

Original PR:

https://github.com/microsoft/weston-mirror/pull/26