### PR TITLE
Add mouse button swap support to RDP backend

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -1580,10 +1580,18 @@ xf_mouseEvent(rdpInput *input, UINT16 flags, UINT16 x, UINT16 y)
 			need_frame = true;
 	}
 
-	if (flags & PTR_FLAGS_BUTTON1)
-		button = BTN_LEFT;
-	else if (flags & PTR_FLAGS_BUTTON2)
-		button = BTN_RIGHT;
+	if (flags & PTR_FLAGS_BUTTON1) {
+		if (peerContext->mouseButtonSwap)
+			button = BTN_RIGHT;
+		else
+			button = BTN_LEFT;
+	}
+	else if (flags & PTR_FLAGS_BUTTON2) {
+		if (peerContext->mouseButtonSwap)
+			button = BTN_LEFT;
+		else
+			button = BTN_RIGHT;
+	}
 	else if (flags & PTR_FLAGS_BUTTON3)
 		button = BTN_MIDDLE;
 

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -275,6 +275,7 @@ struct rdp_peer_context {
 	struct rdp_peers_item item;
 
 	bool button_state[5];
+	bool mouseButtonSwap;
 	char key_state[0xff/8]; // one bit per key.
 	int verticalAccumWheelRotationPrecise;
 	int verticalAccumWheelRotationDiscrete;

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -518,6 +518,7 @@ rail_client_ClientSysparam_callback(int fd, uint32_t mask, void *arg)
 
 	if (sysparam->params & SPI_MASK_SET_MOUSE_BUTTON_SWAP) {
 		rdp_debug(b, "Client: ClientSysparam: mouseButtonSwap:%d\n", sysparam->mouseButtonSwap);
+		peerCtx->mouseButtonSwap = sysparam->mouseButtonSwap;
 	}
 
 	if (sysparam->params & SPI_MASK_SET_WORK_AREA) {


### PR DESCRIPTION
Add mouse button swap support to RDP backend. This is to fix this Github issue:

https://github.com/microsoft/wslg/issues/74