### PR TITLE
fix clipboard crash

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -450,7 +450,7 @@ void rdp_id_manager_free(struct rdp_id_manager *id_manager);
 BOOL rdp_id_manager_allocate_id(struct rdp_id_manager *id_manager, void *object, UINT32 *new_id);
 void rdp_id_manager_free_id(struct rdp_id_manager *id_manager, UINT32 id);
 void dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* title);
-struct wl_event_source *rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, void *data);
+bool rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
 void rdp_defer_rdp_task_done(RdpPeerContext *peerCtx);
 
 // rdprail.c

--- a/libweston/backend-rdp/rdpdisp.c
+++ b/libweston/backend-rdp/rdpdisp.c
@@ -659,11 +659,9 @@ disp_client_monitor_layout_change(DispServerContext* context, const DISPLAY_CONT
 	pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
 	wl_list_insert(&peerCtx->loop_event_source_list, &data->_base_event_source.link);
 	pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);
-	data->_base_event_source.event_source =
-		rdp_defer_rdp_task_to_display_loop(peerCtx,
-			disp_monitor_layout_change_callback,
-			data);
-	if (!data->_base_event_source.event_source) {
+	if (!rdp_defer_rdp_task_to_display_loop(
+			peerCtx, disp_monitor_layout_change_callback,
+			data, &data->_base_event_source.event_source)) {
 		pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
 		wl_list_remove(&data->_base_event_source.link);
 		pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -87,9 +87,9 @@ struct rdp_dispatch_data {
 			pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex); \
 			wl_list_insert(&peerCtx->loop_event_source_list, &dispatch_data->_base_event_source.link); \
 			pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex); \
-			dispatch_data->_base_event_source.event_source = \
-				rdp_defer_rdp_task_to_display_loop(peerCtx, callback, dispatch_data); \
-			if (!dispatch_data->_base_event_source.event_source) { \
+			if (!rdp_defer_rdp_task_to_display_loop( \
+				peerCtx, callback, \
+				dispatch_data, &dispatch_data->_base_event_source.event_source)) { \
 				rdp_debug_error(b, "%s: rdp_queue_deferred_task failed\n", __func__); \
 				pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex); \
 				wl_list_remove(&dispatch_data->_base_event_source.link); \


### PR DESCRIPTION
fix clipboard crash issues. This should fix below two issues.

- crash at copying bitmap data from Windows to Linux, reported at https://github.com/microsoft/wslg/issues/348  and https://github.com/microsoft/wslg/issues/319 .
- crash due to event source being NULL due to multi threading hand off from FreeRDP thread to wayland display loop thread.