### PR TITLE
support image_name in system_distro for RDP AppId message

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -95,7 +95,7 @@ struct weston_rdprail_shell_api {
 
 	/** Get app_id and pid
 	  */
-	pid_t (*get_window_app_id)(struct weston_surface *surface,
+	pid_t (*get_window_app_id)(void *shell_context, struct weston_surface *surface,
 				char *app_id, size_t app_id_size, char *image_name, size_t image_name_size);
 
 	/** Start/stop application list update

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -645,8 +645,8 @@ rail_client_ClientGetAppidReq_callback(int fd, uint32_t mask, void *arg)
 			goto Exit;
 		}
 
-		pid = b->rdprail_shell_api->get_window_app_id(
-					surface, &appId[0], sizeof(appId)-1, &imageName[0], sizeof(imageName)-1);
+		pid = b->rdprail_shell_api->get_window_app_id(b->rdprail_shell_context,
+					surface, &appId[0], sizeof(appId), &imageName[0], sizeof(imageName));
 		if (appId[0] == '\0') {
 			rdp_debug_error(b, "Client: ClientGetAppidReq: WindowId:0x%x does not have appId, or not top level window.\n", getAppidReq->windowId);
 			goto Exit;

--- a/rdprail-shell/shell.h
+++ b/rdprail-shell/shell.h
@@ -200,5 +200,6 @@ void app_list_destroy(struct desktop_shell *shell);
 pixman_image_t *app_list_load_icon_file(struct desktop_shell *shell, const char *key);
 bool app_list_start_backend_update(struct desktop_shell *shell, char *clientLanguageId);
 void app_list_stop_backend_update(struct desktop_shell *shell);
+void app_list_find_image_name(struct desktop_shell *shell, pid_t pid, char *image_name, size_t image_name_size, bool is_wayland);
 // img-load.c
 pixman_image_t *load_icon_image(struct desktop_shell *shell, const char *filename);


### PR DESCRIPTION
This PR does...
1: query image name in user-distro from system-distro.
2: report image name in Windows's style path in RDP AppId message.
3: Add fallback for appId from image name and vise versa.