### PR TITLE
fix shared memory 'File exists' error

### DIFF
--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -2105,9 +2105,11 @@ rdp_rail_update_window(struct weston_surface *surface, struct update_window_iter
 				if (b->use_gfxredir) {
 					assert(rail_state->isUpdatePending == FALSE);
 
-					if (rail_state->surfaceBuffer)
+					if (rail_state->surfaceBuffer) {
 						rdp_destroy_shared_buffer(surface);
-
+						/* at window resize, reset name as old name might still be referenced by client */
+						rail_state->shared_memory.name[0] = '\0';
+					}
 					assert(rail_state->surfaceBuffer == NULL);
 					assert(rail_state->shared_memory.addr == NULL);
 					rail_state->shared_memory.size = copyBufferSize;

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -187,7 +187,7 @@ rdp_allocate_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_memor
 	}
 
 	rdp_debug_verbose(b, "%s: allocated %d: %s (%ld bytes) at %p\n",
-		__func__, fd, shared_memory->name, shared_memory->size, shared_memory->addr);
+		__func__, fd, shared_memory->name, shared_memory->size, addr);
 
 	shared_memory->fd = fd;
 	shared_memory->addr = addr;
@@ -211,6 +211,10 @@ error_exit:
 void
 rdp_free_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_memory *shared_memory)
 {
+	rdp_debug_verbose(b, "%s: freed %d: %s (%ld bytes) at %p\n", __func__,
+		shared_memory->fd, shared_memory->name,
+		shared_memory->size, shared_memory->addr);
+
 	if (shared_memory->addr) {
 		munmap(shared_memory->addr, shared_memory->size);
 		shared_memory->addr = NULL;


### PR DESCRIPTION
fix shared memory 'File exists' error, like..

rdp_allocate_shared_memory: Failed to open "/mnt/shared_memory/{29210c3e-35f4-47de-8654-c05accc20ab7}" with error: File exists