### PR TITLE
Build weston with FreeRDP 3.0

### DIFF
--- a/libweston/backend-rdp/meson.build
+++ b/libweston/backend-rdp/meson.build
@@ -4,19 +4,28 @@ endif
 
 config_h.set('BUILD_RDP_COMPOSITOR', '1')
 
-dep_frdp = dependency('freerdp2', version: '>= 2.0.0', required: false)
+dep_frdp = dependency('freerdp3', version: '>= 3.0.0', required: false)
 if not dep_frdp.found()
-	error('RDP-backend requires freerdp2 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+	dep_frdp = dependency('freerdp2', version: '>= 2.0.0', required: false)
+	if not dep_frdp.found()
+		error('RDP-backend requires freerdp2 or 3 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+	endif
 endif
 
-dep_frdp_server = dependency('freerdp-server2', version: '>= 2.0.0', required: false)
+dep_frdp_server = dependency('freerdp-server3', version: '>= 3.0.0', required: false)
 if not dep_frdp_server.found()
-	error('RDP-backend requires freerdp2-server2 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+	dep_frdp_server = dependency('freerdp-server2', version: '>= 2.0.0', required: false)
+	if not dep_frdp_server.found()
+		error('RDP-backend requires freerdp-server2 or 3 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+	endif
 endif
 
-dep_wpr = dependency('winpr2', version: '>= 2.0.0', required: false)
+dep_wpr = dependency('winpr3', version: '>= 3.0.0', required: false)
 if not dep_wpr.found()
-	error('RDP-backend requires winpr2 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+	dep_wpr = dependency('winpr2', version: '>= 2.0.0', required: false)
+	if not dep_wpr.found()
+		error('RDP-backend requires winpr2 or 3 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+	endif
 endif
 
 dep_rdpapplist = dependency('rdpapplist', version: '>= 1.0.0', required: false)

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -45,6 +45,7 @@
 
 #include "rdp.h"
 
+#include <winpr/version.h>
 #include <winpr/input.h>
 
 #if FREERDP_VERSION_MAJOR >= 2
@@ -1061,8 +1062,11 @@ struct rdp_to_xkb_keyboard_layout rdp_keyboards[] = {
 	//       but Xkb doesn't have that layout in "ir" group.
 	{KBD_FARSI, "ir", "pes"},
 	// 0x50429 is for Dari(Afghanistan)
-	// TODO: define KBD_DARI in winpr's keyboard.h
+#if WINPR_VERSION_MAJOR >= 3
+	{KBD_PERSIAN, "af", "basic"},
+#else
 	{0x50429, "af", "basic"},
+#endif
 	{KBD_VIETNAMESE, "vn", 0},
 	{KBD_ARMENIAN_EASTERN, "am", 0},
 	{KBD_AZERI_LATIN, 0, 0},
@@ -1944,7 +1948,11 @@ rdp_peer_init(freerdp_peer *client, struct rdp_backend *b)
 
 	client->update->SuppressOutput = (pSuppressOutput)xf_suppress_output;
 
+#if FREERDP_VERSION_MAJOR >= 3
+	input = client->context->input;
+#else
 	input = client->input;
+#endif
 	input->SynchronizeEvent = xf_input_synchronize_event;
 	input->MouseEvent = xf_mouseEvent;
 	input->ExtendedMouseEvent = xf_extendedMouseEvent;
@@ -2267,6 +2275,14 @@ rdp_backend_create(struct weston_compositor *compositor,
 		rdp_debug(b, "  %s\n", environ[i]);
 	}
 	rdp_debug(b, "RDP backend: Environment dump - end\n");
+
+#ifdef FREERDP_GIT_REVISION
+	rdp_debug(b, "RDP backend: FreeRDP version: %s, Git version: %s\n",
+		FREERDP_VERSION_FULL, FREERDP_GIT_REVISION);
+#else
+	rdp_debug(b, "RDP backend: FreeRDP version: %s\n",
+		FREERDP_VERSION_FULL);
+#endif
 
 	compositor->backend = &b->base;
 

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -4030,16 +4030,22 @@ rdp_rail_backend_create(struct rdp_backend *b)
 		use_gfxredir = false;
 
 		dlerror(); /* clear error */
+#if FREERDP_VERSION_MAJOR >= 3
+		b->libFreeRDPServer = dlopen("libfreerdp-server3.so", RTLD_NOW);
+#else
 		b->libFreeRDPServer = dlopen("libfreerdp-server2.so", RTLD_NOW);
+#endif
 		if (!b->libFreeRDPServer) {
-			rdp_debug_error(b, "dlopen(libfreerdp-server2.so) failed with %s\n", dlerror());
+			rdp_debug_error(b, "dlopen(libfreerdp-server%d.so) failed with %s\n",
+				FREERDP_VERSION_MAJOR, dlerror());
 		} else {
 			*(void **)(&b->gfxredir_server_context_new) = dlsym(b->libFreeRDPServer, "gfxredir_server_context_new");
 			*(void **)(&b->gfxredir_server_context_free) = dlsym(b->libFreeRDPServer, "gfxredir_server_context_free");
 			if (b->gfxredir_server_context_new && b->gfxredir_server_context_new) {
 				use_gfxredir = true;
 			} else {
-				rdp_debug(b, "libfreerdp-server2.so doesn't support graphics redirection API.\n");
+				rdp_debug(b, "libfreerdp-server%d.so doesn't support graphics redirection API.\n",
+					FREERDP_VERSION_MAJOR);
 				dlclose(b->libFreeRDPServer);
 				b->libFreeRDPServer = NULL;
 			}

--- a/rdprail-shell/meson.build
+++ b/rdprail-shell/meson.build
@@ -1,7 +1,12 @@
 if get_option('shell-rdprail')
-	dep_winpr = dependency('winpr2', version: '>= 2.0.0', required: false)
+	dep_winpr = dependency('winpr3', version: '>= 3.0.0', required: false)
 	if dep_winpr.found()
-		config_h.set('HAVE_WINPR2', '1')
+		config_h.set('HAVE_WINPR', '1')
+	else
+		dep_winpr = dependency('winpr2', version: '>= 2.0.0', required: false)
+		if dep_winpr.found()
+			config_h.set('HAVE_WINPR', '1')
+		endif
 	endif
 	dep_librsvg = dependency('librsvg-2.0', version: '>= 2.36.0', required: false)
 	if dep_librsvg.found()


### PR DESCRIPTION
This makes weston buildable with FreeRDP 3.0 (which is head of current FreeRDP project) as well as FreeRDP 2.x. 3,0 takes priority if installed both. This is for validation purpose for upstreaming WSLg changes to FreeRDP project.


