### PR TITLE
disable keep display power on by screen update by default

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -186,6 +186,8 @@ struct rdp_backend {
 
 	bool enable_window_zorder_sync;
 
+	bool keep_display_power_by_screenupdate;
+
 	bool enable_hi_dpi_support;
 	bool enable_fractional_hi_dpi_support;
 	uint32_t debug_desktop_scaling_factor; /* must be between 100 to 500 */

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -2615,7 +2615,7 @@ rdp_rail_output_repaint(struct weston_output *output, pixman_region32_t *damage)
 			rdp_rail_sync_window_zorder(b->compositor);
 			peerCtx->is_window_zorder_dirty = false;
 		}
-		if (iter_data.isUpdatePending) {
+		if (iter_data.isUpdatePending && b->keep_display_power_by_screenupdate) {
 			/* By default, compositor won't update idle timer by screen activity,
 			   thus, here manually call wake function to postpone idle timer when
 			   RDP backend sends frame to client. */
@@ -4119,6 +4119,14 @@ rdp_rail_backend_create(struct rdp_backend *b)
 			b->enable_window_zorder_sync = false;
 	}
 	rdp_debug(b, "RDP backend: enable_window_zorder_sync = %d\n", b->enable_window_zorder_sync);
+
+	b->keep_display_power_by_screenupdate = false;
+	s = getenv("WESTON_RDP_ENABLE_DISPLAY_POWER_BY_SCREENUPDATE");
+	if (s) {
+		if (strcmp(s, "true") == 0)
+			b->keep_display_power_by_screenupdate = true;
+	}
+	rdp_debug(b, "RDP backend: keep_display_power_by_screenupdate = %d\n", b->keep_display_power_by_screenupdate);
 
 	b->rdprail_shell_name = NULL;
 


### PR DESCRIPTION
This to address https://github.com/microsoft/wslg/issues/380. There is several reports regarding to display to not turning off, mainly due to application updating screen even no interaction with user, thus disable this by default.