### PR TITLE
rdprail-shell should not call weston_desktop_api_maximized_requested directly

### DIFF
--- a/libweston-desktop/libweston-desktop.c
+++ b/libweston-desktop/libweston-desktop.c
@@ -225,7 +225,7 @@ weston_desktop_api_fullscreen_requested(struct weston_desktop *desktop,
 						  desktop->user_data);
 }
 
-WL_EXPORT void
+void
 weston_desktop_api_maximized_requested(struct weston_desktop *desktop,
 				       struct weston_desktop_surface *surface,
 				       bool maximized)

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -2627,10 +2627,7 @@ shell_backend_request_window_maximize(struct weston_surface *surface)
 	if (api && api->is_xwayland_surface(surface)) {
 		api->set_maximized(surface, true);
 	} else {
-		struct weston_desktop_surface *desktop_surface =
-			weston_surface_get_desktop_surface(surface);
-
-		weston_desktop_api_maximized_requested(shsurf->shell->desktop, desktop_surface, true);
+		set_maximized(shsurf, true);
 	}
 }
 
@@ -2659,10 +2656,7 @@ shell_backend_request_window_restore(struct weston_surface *surface)
 		if (api && api->is_xwayland_surface(surface)) {
 			api->set_maximized(surface, false);
 		} else {
-			struct weston_desktop_surface *desktop_surface =
-				weston_surface_get_desktop_surface(surface);
-
-			weston_desktop_api_maximized_requested(shsurf->shell->desktop, desktop_surface, false);
+			set_maximized(shsurf, false);
 		}
 	}
 }


### PR DESCRIPTION
rdprail-shell should not call weston_desktop_api_maximized_requested directly, and it should not force WL_EXPORT which is added as a part of WSLg change previously.