### PR TITLE
backend-rdp: port fixes from upstream

### DIFF
--- a/libweston/backend-rdp/meson.build
+++ b/libweston/backend-rdp/meson.build
@@ -6,25 +6,25 @@ config_h.set('BUILD_RDP_COMPOSITOR', '1')
 
 dep_frdp = dependency('freerdp3', version: '>= 3.0.0', required: false)
 if not dep_frdp.found()
-	dep_frdp = dependency('freerdp2', version: '>= 2.0.0', required: false)
+	dep_frdp = dependency('freerdp2', version: '>= 2.2.0', required: false)
 	if not dep_frdp.found()
-		error('RDP-backend requires freerdp2 or 3 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+		error('RDP-backend requires freerdp >= 2.2.0 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
 	endif
 endif
 
 dep_frdp_server = dependency('freerdp-server3', version: '>= 3.0.0', required: false)
 if not dep_frdp_server.found()
-	dep_frdp_server = dependency('freerdp-server2', version: '>= 2.0.0', required: false)
+	dep_frdp_server = dependency('freerdp-server2', version: '>= 2.2.0', required: false)
 	if not dep_frdp_server.found()
-		error('RDP-backend requires freerdp-server2 or 3 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+		error('RDP-backend requires freerdp-server >= 2.2.0 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
 	endif
 endif
 
 dep_wpr = dependency('winpr3', version: '>= 3.0.0', required: false)
 if not dep_wpr.found()
-	dep_wpr = dependency('winpr2', version: '>= 2.0.0', required: false)
+	dep_wpr = dependency('winpr2', version: '>= 2.2.0', required: false)
 	if not dep_wpr.found()
-		error('RDP-backend requires winpr2 or 3 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
+		error('RDP-backend requires winpr >= 2.2.0 which was not found. Or, you can use \'-Dbackend-rdp=false\'.')
 	endif
 endif
 
@@ -33,36 +33,8 @@ if dep_rdpapplist.found()
 	config_h.set('HAVE_FREERDP_RDPAPPLIST_H', '1')
 endif
 
-if cc.has_header('freerdp/version.h', dependencies: dep_frdp)
-	config_h.set('HAVE_FREERDP_VERSION_H', '1')
-endif
-
 if cc.has_header('freerdp/channels/gfxredir.h', dependencies: dep_frdp)
 	config_h.set('HAVE_FREERDP_GFXREDIR_H', '1')
-endif
-
-if cc.has_member(
-	'SURFACE_BITS_COMMAND', 'bmp',
-	dependencies : dep_frdp,
-	prefix : '#include <freerdp/update.h>'
-)
-	config_h.set('HAVE_SURFACE_BITS_BMP', '1')
-endif
-
-if cc.has_type(
-	'enum SURFCMD_CMDTYPE',
-	dependencies : dep_frdp,
-	prefix : '#include <freerdp/update.h>'
-)
-	config_h.set('HAVE_SURFCMD_CMDTYPE', '1')
-endif
-
-if cc.has_function(
-	'nsc_context_set_parameters',
-	dependencies : dep_frdp,
-	prefix: '#include <freerdp/codec/nsc.h>'
-)
-	config_h.set('HAVE_NSC_CONTEXT_SET_PARAMETERS', '1')
 endif
 
 if cc.has_member(

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -26,55 +26,7 @@
 #ifndef RDP_H
 #define RDP_H
 
-#if HAVE_FREERDP_VERSION_H
 #include <freerdp/version.h>
-#else
-/* assume it's a early 1.1 version */
-#define FREERDP_VERSION_MAJOR 1
-#define FREERDP_VERSION_MINOR 1
-#define FREERDP_VERSION_REVISION 0
-#endif
-
-#define FREERDP_VERSION_NUMBER ((FREERDP_VERSION_MAJOR * 0x10000) + \
-		(FREERDP_VERSION_MINOR * 0x100) + FREERDP_VERSION_REVISION)
-
-
-#if FREERDP_VERSION_NUMBER >= 0x10201
-#define HAVE_SKIP_COMPRESSION
-#endif
-
-#if FREERDP_VERSION_NUMBER < 0x10202
-#	define FREERDP_CB_RET_TYPE void
-#	define FREERDP_CB_RETURN(V) return
-#	define NSC_RESET(C, W, H)
-#	define RFX_RESET(C, W, H) do { rfx_context_reset(C); C->width = W; C->height = H; } while(0)
-#else
-#if FREERDP_VERSION_MAJOR >= 2
-#	define NSC_RESET(C, W, H) nsc_context_reset(C, W, H)
-#	define RFX_RESET(C, W, H) rfx_context_reset(C, W, H)
-#else
-#	define NSC_RESET(C, W, H) do { nsc_context_reset(C); C->width = W; C->height = H; } while(0)
-#	define RFX_RESET(C, W, H) do { rfx_context_reset(C); C->width = W; C->height = H; } while(0)
-#endif
-#define FREERDP_CB_RET_TYPE BOOL
-#define FREERDP_CB_RETURN(V) return TRUE
-#endif
-
-#ifdef HAVE_SURFACE_BITS_BMP
-#define SURFACE_BPP(cmd) cmd.bmp.bpp
-#define SURFACE_CODECID(cmd) cmd.bmp.codecID
-#define SURFACE_WIDTH(cmd) cmd.bmp.width
-#define SURFACE_HEIGHT(cmd) cmd.bmp.height
-#define SURFACE_BITMAP_DATA(cmd) cmd.bmp.bitmapData
-#define SURFACE_BITMAP_DATA_LEN(cmd) cmd.bmp.bitmapDataLength
-#else
-#define SURFACE_BPP(cmd) cmd.bpp
-#define SURFACE_CODECID(cmd) cmd.codecID
-#define SURFACE_WIDTH(cmd) cmd.width
-#define SURFACE_HEIGHT(cmd) cmd.height
-#define SURFACE_BITMAP_DATA(cmd) cmd.bitmapData
-#define SURFACE_BITMAP_DATA_LEN(cmd) cmd.bitmapDataLength
-#endif
 
 #include <freerdp/freerdp.h>
 #include <freerdp/listener.h>
@@ -115,15 +67,7 @@
 #define RDP_MODE_FREQ 60 * 1000
 #define RDP_MAX_MONITOR 16 // RDP max monitors.
 
-#if FREERDP_VERSION_MAJOR >= 2 && defined(PIXEL_FORMAT_BGRA32) && !defined(PIXEL_FORMAT_B8G8R8A8)
-	/* The RDP API is truly wonderful: the pixel format definition changed
-	 * from BGRA32 to B8G8R8A8, but some versions ship with a definition of
-	 * PIXEL_FORMAT_BGRA32 which doesn't actually build. Try really, really,
-	 * hard to find one which does. */
-#	define DEFAULT_PIXEL_FORMAT PIXEL_FORMAT_BGRA32
-#else
-#	define DEFAULT_PIXEL_FORMAT RDP_PIXEL_FORMAT_B8G8R8A8
-#endif
+#define DEFAULT_PIXEL_FORMAT PIXEL_FORMAT_BGRA32
 
 struct rdp_output;
 struct rdp_clipboard_data_source;


### PR DESCRIPTION
backend-rdp: pick up changes from upstream to keep backend-rdp in sync with current upstream's main (as part of preparing to WSLg upstreaming).

Below are the changes between 9.0 tag (where current WSLg weston based on) and the latest main as of today (11/09/2021).

https://github.com/wayland-project/weston/commit/5b357a4bbba0562063c6738f52995ea0823174f2
https://github.com/wayland-project/weston/commit/7d2da94b05eb0ca1fda75e45254cbe05ceea7088
https://github.com/wayland-project/weston/commit/e3f447eee87a275ebef27e2a561fc9312d5e1bcf
https://github.com/wayland-project/weston/commit/495a8921902e87468d510228e5046dea7a907370