### PR TITLE
backend-rdp: hold mutex while accessing rail_state from non-compositor thread

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -137,6 +137,7 @@ struct rdp_id_manager {
 	UINT32 id_total;
 	UINT32 id_used;
 	pthread_mutex_t mutex;
+	pid_t mutex_tid;
 	struct hash_table *hash_table;
 };
 
@@ -450,6 +451,8 @@ BOOL rdp_allocate_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_
 void rdp_free_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_memory *shared_memory);
 BOOL rdp_id_manager_init(struct rdp_backend *rdp_backend, struct rdp_id_manager *id_manager, UINT32 low_limit, UINT32 high_limit);
 void rdp_id_manager_free(struct rdp_id_manager *id_manager);
+void rdp_id_manager_lock(struct rdp_id_manager *id_manager);
+void rdp_id_manager_unlock(struct rdp_id_manager *id_manager);
 void *rdp_id_manager_lookup(struct rdp_id_manager *id_manager, UINT32 id);
 void rdp_id_manager_for_each(struct rdp_id_manager *id_manager, hash_table_iterator_func_t func, void *data);
 BOOL rdp_id_manager_allocate_id(struct rdp_id_manager *id_manager, void *object, UINT32 *new_id);

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -136,6 +136,7 @@ struct rdp_id_manager {
 	UINT32 id_high_limit;
 	UINT32 id_total;
 	UINT32 id_used;
+	pthread_mutex_t mutex;
 	struct hash_table *hash_table;
 };
 
@@ -449,6 +450,8 @@ BOOL rdp_allocate_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_
 void rdp_free_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_memory *shared_memory);
 BOOL rdp_id_manager_init(struct rdp_backend *rdp_backend, struct rdp_id_manager *id_manager, UINT32 low_limit, UINT32 high_limit);
 void rdp_id_manager_free(struct rdp_id_manager *id_manager);
+void *rdp_id_manager_lookup(struct rdp_id_manager *id_manager, UINT32 id);
+void rdp_id_manager_for_each(struct rdp_id_manager *id_manager, hash_table_iterator_func_t func, void *data);
 BOOL rdp_id_manager_allocate_id(struct rdp_id_manager *id_manager, void *object, UINT32 *new_id);
 void rdp_id_manager_free_id(struct rdp_id_manager *id_manager, UINT32 id);
 void dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* title);

--- a/libweston/backend-rdp/rdpdisp.c
+++ b/libweston/backend-rdp/rdpdisp.c
@@ -593,7 +593,7 @@ disp_monitor_layout_change(DispServerContext* context, const DISPLAY_CONTROL_MON
 	peerCtx->rail_grfx_server_context->ResetGraphics(peerCtx->rail_grfx_server_context, &resetGraphics);
 
 	/* force recreate all surface and redraw. */
-	hash_table_for_each(peerCtx->windowId.hash_table, disp_force_recreate_iter, NULL);
+	rdp_id_manager_for_each(&peerCtx->windowId, disp_force_recreate_iter, NULL);
 	weston_compositor_damage_all(b->compositor);
 
 Exit:

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -311,7 +311,7 @@ rail_client_Activate_callback(int fd, uint32_t mask, void *arg)
 		b->rdprail_shell_api->request_window_activate &&
 		b->rdprail_shell_context) {
 		if (activate->windowId && activate->enabled) {
-			surface = (struct weston_surface *)hash_table_lookup(peerCtx->windowId.hash_table, activate->windowId);
+			surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, activate->windowId);
 			if (!surface)
 				rdp_debug_error(b, "Client: ClientActivate: WindowId:0x%x is not found.\n", activate->windowId);
 		}
@@ -348,7 +348,7 @@ rail_client_SnapArrange_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	surface = (struct weston_surface *)hash_table_lookup(peerCtx->windowId.hash_table, snap->windowId);
+	surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, snap->windowId);
 	if (surface) {
 		rail_state = (struct weston_surface_rail_state *)surface->backend_state;
 		if (b->rdprail_shell_api &&
@@ -394,7 +394,7 @@ rail_client_WindowMove_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	surface = (struct weston_surface *)hash_table_lookup(peerCtx->windowId.hash_table, windowMove->windowId);
+	surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, windowMove->windowId);
 	if (surface) {
 		if (b->rdprail_shell_api &&
 			b->rdprail_shell_api->request_window_move) {
@@ -429,7 +429,7 @@ rail_client_Syscommand_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	surface = (struct weston_surface *)hash_table_lookup(peerCtx->windowId.hash_table, syscommand->windowId);
+	surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, syscommand->windowId);
 	if (!surface) {
 		rdp_debug_error(b, "Client: ClientSyscommand: WindowId:0x%x is not found.\n", syscommand->windowId);
 		goto Exit;
@@ -639,7 +639,7 @@ rail_client_ClientGetAppidReq_callback(int fd, uint32_t mask, void *arg)
 	if (b->rdprail_shell_api &&
 		b->rdprail_shell_api->get_window_app_id) {
 
-		surface = (struct weston_surface *)hash_table_lookup(peerCtx->windowId.hash_table, getAppidReq->windowId);
+		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, getAppidReq->windowId);
 		if (!surface) {
 			rdp_debug_error(b, "Client: ClientGetAppidReq: WindowId:0x%x is not found.\n", getAppidReq->windowId);
 			goto Exit;
@@ -1130,7 +1130,7 @@ gfxredir_client_present_buffer_ack(GfxRedirServerContext* context, const GFXREDI
 
 	peerCtx->acknowledgedFrameId = (UINT32)presentAck->presentId;
 
-	surface = (struct weston_surface *)hash_table_lookup(peerCtx->windowId.hash_table, presentAck->windowId);
+	surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, presentAck->windowId);
 	if (surface) {
 		rail_state = (struct weston_surface_rail_state *)surface->backend_state;
 		rail_state->isUpdatePending = FALSE;
@@ -1333,7 +1333,7 @@ rdp_rail_create_window(struct wl_listener *listener, void *data)
 	/* windowId can be assigned only after activation completed */
 	if (!rdp_id_manager_allocate_id(&peerCtx->windowId, (void*)surface, &window_id)) {
 		rail_state->error = true;
-		rdp_debug_error(b, "CreateWindow(): fail to insert windowId.hash_table (windowId:%d surface:%p.\n",
+		rdp_debug_error(b, "CreateWindow(): fail to insert windowId (windowId:%d surface:%p.\n",
 				 window_id, surface);
 		return;
 	}
@@ -2602,7 +2602,7 @@ rdp_rail_output_repaint(struct weston_output *output, pixman_region32_t *damage)
 			 peerCtx->currentFrameId, peerCtx->acknowledgedFrameId, peerCtx->isAcknowledgedSuspended);
 		struct update_window_iter_data iter_data = {};
 		iter_data.output_id = output->id;
-		hash_table_for_each(peerCtx->windowId.hash_table, rdp_rail_update_window_iter, (void*) &iter_data);
+		rdp_id_manager_for_each(&peerCtx->windowId, rdp_rail_update_window_iter, (void*) &iter_data);
 		if (iter_data.needEndFrame) {
 			/* if frame is started at above iteration, send EndFrame here. */
 			RDPGFX_END_FRAME_PDU endFrame = {};
@@ -3151,8 +3151,7 @@ rdp_rail_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 {
 	struct rdp_loop_event_source *current, *next;
 
-	if (context->windowId.hash_table)
-		hash_table_for_each(context->windowId.hash_table, rdp_rail_destroy_window_iter, NULL);
+	rdp_id_manager_for_each(&context->windowId, rdp_rail_destroy_window_iter, NULL);
 
 #ifdef HAVE_FREERDP_RDPAPPLIST_H
 	if (context->applist_server_context) {
@@ -3555,7 +3554,7 @@ rdp_rail_dump_window_binding(struct weston_keyboard *keyboard,
 		size_t len;
 		FILE *fp = open_memstream(&str, &len);
 		assert(fp);
-		fprintf(fp,"\nrdp debug binding 'W' - dump all window from window hash_table.\n");
+		fprintf(fp,"\nrdp debug binding 'W' - dump all window.\n");
 		peerCtx = (RdpPeerContext *)b->rdp_peer->context;
 		dump_id_manager_state(fp, &peerCtx->windowId, "windowId");
 		dump_id_manager_state(fp, &peerCtx->surfaceId, "surfaceId");
@@ -3565,7 +3564,7 @@ rdp_rail_dump_window_binding(struct weston_keyboard *keyboard,
 #endif // HAVE_FREERDP_GFXREDIR_H
 		context.peerCtx = peerCtx;
 		context.fp = fp;
-		hash_table_for_each(peerCtx->windowId.hash_table, rdp_rail_dump_window_iter, (void*)&context);
+		rdp_id_manager_for_each(&peerCtx->windowId, rdp_rail_dump_window_iter, (void*)&context);
 		err = fclose(fp);
 		assert(err == 0);
 		rdp_debug_error(b, "%s", str);

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -287,9 +287,9 @@ rdp_id_manager_unlock(struct rdp_id_manager *id_manager)
 {
 	ASSERT_NOT_COMPOSITOR_THREAD(id_manager->rdp_backend);
 
-	pthread_mutex_unlock(&id_manager->mutex);
 	/* At unlock, restore compositor thread as owner */
 	id_manager->mutex_tid = id_manager->rdp_backend->compositor_tid;
+	pthread_mutex_unlock(&id_manager->mutex);
 }
 
 void *

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -229,6 +229,8 @@ rdp_free_shared_memory(struct rdp_backend *b, struct weston_rdp_shared_memory *s
 BOOL
 rdp_id_manager_init(struct rdp_backend *rdp_backend, struct rdp_id_manager *id_manager, UINT32 low_limit, UINT32 high_limit)
 {
+	ASSERT_COMPOSITOR_THREAD(rdp_backend);
+
 	assert(id_manager->hash_table == NULL);
 	assert(low_limit > 0);
 	assert(low_limit < high_limit);
@@ -240,11 +242,10 @@ rdp_id_manager_init(struct rdp_backend *rdp_backend, struct rdp_id_manager *id_m
 	id_manager->id = low_limit;
 	id_manager->hash_table = hash_table_create();
 	if (id_manager->hash_table) {
-		pthread_mutexattr_t mat;
-		pthread_mutexattr_init(&mat);
-		pthread_mutexattr_settype(&mat, PTHREAD_MUTEX_RECURSIVE);
-		pthread_mutex_init(&id_manager->mutex, &mat);
-		pthread_mutexattr_destroy(&mat);
+		pthread_mutex_init(&id_manager->mutex, NULL);
+		/* by default, pretend mutex is held by compositor thread,
+		   so it can be accessed without trigerring assert */
+		id_manager->mutex_tid = rdp_backend->compositor_tid;
 	} else {
 		rdp_debug_error(rdp_backend, "%s: unable to create hash_table.\n", __func__);
 	}
@@ -254,12 +255,15 @@ rdp_id_manager_init(struct rdp_backend *rdp_backend, struct rdp_id_manager *id_m
 void
 rdp_id_manager_free(struct rdp_id_manager *id_manager)
 {
+	ASSERT_COMPOSITOR_THREAD(id_manager->rdp_backend);
+
 	if (id_manager->id_used != 0)
 		rdp_debug_error(id_manager->rdp_backend, "%s: possible id leak: %d\n", __func__, id_manager->id_used);
 	if (id_manager->hash_table) {
 		hash_table_destroy(id_manager->hash_table);
 		pthread_mutex_destroy(&id_manager->mutex);
 	}
+	id_manager->mutex_tid = 0;
 	id_manager->hash_table = NULL;
 	id_manager->id = 0;
 	id_manager->id_low_limit = 0;
@@ -269,34 +273,54 @@ rdp_id_manager_free(struct rdp_id_manager *id_manager)
 	id_manager->rdp_backend = NULL;
 }
 
+void
+rdp_id_manager_lock(struct rdp_id_manager *id_manager)
+{
+	ASSERT_NOT_COMPOSITOR_THREAD(id_manager->rdp_backend);
+
+	pthread_mutex_lock(&id_manager->mutex);
+	id_manager->mutex_tid = rdp_get_tid();
+}
+
+void
+rdp_id_manager_unlock(struct rdp_id_manager *id_manager)
+{
+	ASSERT_NOT_COMPOSITOR_THREAD(id_manager->rdp_backend);
+
+	pthread_mutex_unlock(&id_manager->mutex);
+	/* At unlock, restore compositor thread as owner */
+	id_manager->mutex_tid = id_manager->rdp_backend->compositor_tid;
+}
+
 void *
 rdp_id_manager_lookup(struct rdp_id_manager *id_manager, UINT32 id)
 {
-	void *p;
+	/* lookup can be done under compositor thread or after mutex held by rdp_id_manager_lock */
+	assert(id_manager->mutex_tid == rdp_get_tid());
+
 	assert(id_manager->hash_table);
-	pthread_mutex_lock(&id_manager->mutex);
-	p = hash_table_lookup(id_manager->hash_table, id);
-	pthread_mutex_unlock(&id_manager->mutex);
-	return p;
+	return hash_table_lookup(id_manager->hash_table, id);
 }
 
 void
 rdp_id_manager_for_each(struct rdp_id_manager *id_manager, hash_table_iterator_func_t func, void *data)
 {
+	ASSERT_COMPOSITOR_THREAD(id_manager->rdp_backend);
+
 	if (!id_manager->hash_table)
 		return;
 
-	pthread_mutex_lock(&id_manager->mutex);
 	hash_table_for_each(id_manager->hash_table, func, data);
-	pthread_mutex_unlock(&id_manager->mutex);
 }
 
 BOOL
 rdp_id_manager_allocate_id(struct rdp_id_manager *id_manager, void *object, UINT32 *new_id)
 {
 	UINT32 id = 0;
+
+	ASSERT_COMPOSITOR_THREAD(id_manager->rdp_backend);
 	assert(id_manager->hash_table);
-	pthread_mutex_lock(&id_manager->mutex);
+
 	for(;id_manager->id_used < id_manager->id_total;) {
 		id = id_manager->id++;
 		if (id_manager->id == id_manager->id_high_limit)
@@ -311,18 +335,19 @@ rdp_id_manager_allocate_id(struct rdp_id_manager *id_manager, void *object, UINT
 			break;
 		}
 	}
-	pthread_mutex_unlock(&id_manager->mutex);
 	return id != 0;
 }
 
 void
 rdp_id_manager_free_id(struct rdp_id_manager *id_manager, UINT32 id)
 {
+	ASSERT_COMPOSITOR_THREAD(id_manager->rdp_backend);
 	assert(id_manager->hash_table);
+
 	pthread_mutex_lock(&id_manager->mutex);
 	hash_table_remove(id_manager->hash_table, id);
-	id_manager->id_used--;
 	pthread_mutex_unlock(&id_manager->mutex);
+	id_manager->id_used--;
 }
 
 void


### PR DESCRIPTION
Hold mutex while accessing rail_state from non-compositor thread. 

This blocks rail_state to be freed by window destruction. This mutex is **not** for synchronize state of rail_state (or any state of surface), it is just for blocking destruction while it's being accessed from non-compositor thread.