### PR TITLE
fix clipboard race condition ends up as assertion failure

### DIFF
--- a/libweston/backend-rdp/rdpclip.c
+++ b/libweston/backend-rdp/rdpclip.c
@@ -885,6 +885,60 @@ send_exit:
 	return 0; 
 }
 
+/* client's reply with error for data request, clean up */ 
+static int
+clipboard_data_source_fail(int fd, uint32_t mask, void *arg)
+{
+	struct rdp_clipboard_data_source *source = (struct rdp_clipboard_data_source *)arg;
+	freerdp_peer *client = (freerdp_peer *) source->context;
+	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
+	struct rdp_backend *b = peerCtx->rdpBackend;
+
+	rdp_debug_clipboard_verbose(b, "RDP %s (%p:%s) fd:%d\n", __func__,
+		source, clipboard_data_source_state_to_string(source), fd);
+
+	ASSERT_COMPOSITOR_THREAD(b);
+
+	assert(source->data_source_fd == fd);
+	/* this data source must be tracked as inflight */
+	assert(source == peerCtx->clipboard_inflight_client_data_source);
+
+	/* remove event source now, and if write is failed with EAGAIN, queue back to display loop. */ 
+	wl_event_source_remove(source->transfer_event_source);
+	source->transfer_event_source = NULL;
+
+	if (source->data_contents.size) {
+		/* if data is recieved, but failed by other reason,
+		   then keep data and format index for future request,
+		   otherwise data is purged at last reference release. */
+		/* wl_array_release(&source->data_contents); */
+		/* wl_array_init(&source->data_contents); */
+	} else {
+		/* data has been never recieved, thus must be empty. */
+		assert(source->data_contents.size == 0);
+		assert(source->data_contents.alloc == 0);
+		assert(source->data_contents.data == NULL);
+		/* clear previous requested format so it can be requested later again. */
+		source->format_index = -1;
+	}
+	/* don't clear format id table, so it allows to retry to get data from client. */
+	/* memset(source->client_format_id_table, 0, sizeof(source->client_format_id_table)); */
+	/* data has never been sent to write(), thus must be no inflight write. */
+	assert(source->inflight_write_count == 0);
+	assert(source->inflight_data_to_write == NULL);
+	assert(source->inflight_data_size == 0);
+	/* data never has been sent to write(), so must not be processed. */
+	assert(source->is_data_processed == FALSE);
+	/* close fd to server clipboard stop pulling data. */
+	close(source->data_source_fd);
+	source->data_source_fd = -1;
+	/* clear inflight data source from client to server. */
+	peerCtx->clipboard_inflight_client_data_source = NULL;
+	clipboard_data_source_unref(source);
+
+	return 0;
+}
+
 /* Send client's clipboard data to the requesting application at server side */
 static int
 clipboard_data_source_write(int fd, uint32_t mask, void *arg)
@@ -1582,48 +1636,15 @@ clipboard_client_format_data_response(CliprdrServerContext* context, const CLIPR
 			clipboard_data_source_state_to_string(source),
 			source->data_response_fail_count);
 
-		if (Success) {
-			assert(source->transfer_event_source == NULL);
-			source->transfer_event_source =
-				wl_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
-						clipboard_data_source_write, source);
-			if (!source->transfer_event_source) {
-				source->state = RDP_CLIPBOARD_SOURCE_FAILED;
-				rdp_debug_clipboard_error(b, "Client: %s (%p:%s) wl_event_loop_add_fd failed\n",
-					__func__, source, clipboard_data_source_state_to_string(source));
-			}
-		}
-
+		assert(source->transfer_event_source == NULL);
+		source->transfer_event_source =
+			wl_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
+				Success ? clipboard_data_source_write : clipboard_data_source_fail, source);
 		if (!source->transfer_event_source) {
-			if (formatDataResponse->msgFlags == CB_RESPONSE_OK) {
-				/* if data is recieved, but failed to sent to write(),
-				   then keep data and format index for future request,
-				   otherwise data is purged at last reference release. */
-				/* wl_array_release(&source->data_contents); */
-				/* wl_array_init(&source->data_contents); */
-			} else {
-				/* data has been never recieved, thus must be empty. */
-				assert(source->data_contents.size == 0);
-				assert(source->data_contents.alloc == 0);
-				assert(source->data_contents.data == NULL);
-				/* clear previous requested format so it can be requested later again. */
-				source->format_index = -1;
-			}
-			/* don't clear format id table, so it allows to retry to get data from client. */
-			/* memset(source->client_format_id_table, 0, sizeof(source->client_format_id_table)); */
-			/* data has never been sent to write(), thus must be no inflight write. */
-			assert(source->inflight_write_count == 0);
-			assert(source->inflight_data_to_write == NULL);
-			assert(source->inflight_data_size == 0);
-			/* data never has been sent to write(), so must not be processed. */
-			assert(source->is_data_processed == FALSE);
-			/* close fd to server clipboard stop pulling data. */
-			close(source->data_source_fd);
-			source->data_source_fd = -1;
-			/* clear inflight data source from client to server. */
-			assert(source == peerCtx->clipboard_inflight_client_data_source);
-			peerCtx->clipboard_inflight_client_data_source = NULL;
-			clipboard_data_source_unref(source);
+			source->state = RDP_CLIPBOARD_SOURCE_FAILED;
+			rdp_debug_clipboard_error(b, "Client: %s (%p:%s) wl_event_loop_add_fd failed\n",
+				__func__, source, clipboard_data_source_state_to_string(source));
+			return -1;
 		}
 	} else {
 		rdp_debug_clipboard(b, "Client: %s client send data without server asking. protocol error", __func__);


### PR DESCRIPTION
This is to address the race condition issue when Windows client responded failure on clipboard request from WSLg. The investigation is done in context of https://github.com/microsoft/wslg/issues/609 and the core dump provided by @edburns.

#0  0x00007fb5f23ae115 in raise () from /lib/libc.so.6
#1  0x00007fb5f239861e in abort () from /lib/libc.so.6
#2  0x00007fb5f2398429 in __assert_fail_base.cold () from /lib/libc.so.6
#3  0x00007fb5f23a6806 in __assert_fail () from /lib/libc.so.6
#4  0x00007fb5f15ccf4c in clipboard_data_source_cancel (base=0x7fb5cc0011a0) at ../libweston/backend-rdp/rdpclip.c:1141
#5  0x00007fb5f23460d8 in weston_seat_set_selection (seat=0x55a956c01b80, source=0x7fb5cc000f50, serial=15342)
    at ../libweston/data-device.c:1149
#6  0x00007fb5f15cd25e in clipboard_data_source_publish (fd=51, mask=1, arg=0x7fb5cc000f50)
    at ../libweston/backend-rdp/rdpclip.c:1199
#7  0x00007fb5f2302c1a in wl_event_loop_dispatch (loop=0x55a95688d790, timeout=timeout@entry=-1)
    at src/event-loop.c:1050
#8  0x00007fb5f23010e5 in wl_display_run (display=0x55a95688da10) at src/wayland-server.c:1351
#9  0x00007fb5f254c613 in wet_main (argc=1, argv=0x7ffefbe12188) at ../compositor/main.c:3438
#10 0x000055a954abb159 in main (argc=7, argv=0x7ffefbe12188) at ../compositor/executable.c:33