### PR TITLE
fix rdp_defer_rdp_task_to_display_loop to not access event_source pointer after signalling event

### DIFF
--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -379,6 +379,7 @@ rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_fun
 					func, data);
 		if (*event_source) {
 			eventfd_write(peerCtx->loop_event_source_fd, 1);
+			return true;
 		} else {
 			rdp_debug_error(b, "%s: wl_event_loop_add_idle failed\n", __func__);
 		}
@@ -386,7 +387,7 @@ rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_fun
 		/* RDP server is not opened, this must not be used */
 		assert(false);
 	}
-	return (*event_source != NULL);
+	return false;
 }
 
 void


### PR DESCRIPTION
fix rdp_defer_rdp_task_to_display_loop. The event_source pointer must not be referenced after signaling the event since it can be reset by display loop thread, thus this leads to take error path in caller even queue/dispatch to display loop has been done successfully. This is reported in the dump at https://github.com/microsoft/wslg/issues/589#issuecomment-1065421334.


