### PR TITLE
remove legacy to_weston_x/to_weston_y macros

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -75,7 +75,7 @@ struct weston_rdprail_shell_api {
 
 	/** Move a window.
 	 */
-	void (*request_window_move)(struct weston_surface *surface, int x, int y);
+	void (*request_window_move)(struct weston_surface *surface, int x, int y, int width, int height);
 
 	/** Snap a window.
 	 */

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -483,20 +483,6 @@ rdp_matrix_transform_scale(struct weston_matrix *matrix, int *sx, int *sy)
 	}
 }
 
-/* TO BE REMOVED */
-static inline int32_t
-to_weston_x(RdpPeerContext *peer, int32_t x)
-{
-	return x - peer->regionClientHeads.extents.x1;
-}
-
-/* TO BE REMOVED */
-static inline int32_t
-to_weston_y(RdpPeerContext *peer, int32_t y)
-{
-	return y - peer->regionClientHeads.extents.y1;
-}
-
 static inline void
 to_weston_scale_only(RdpPeerContext *peer, struct weston_output *output, float scale, int *x, int *y)
 {

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -2665,7 +2665,7 @@ shell_backend_request_window_restore(struct weston_surface *surface)
 }
 
 static void
-shell_backend_request_window_move(struct weston_surface *surface, int x, int y)
+shell_backend_request_window_move(struct weston_surface *surface, int x, int y, int width, int height)
 {
 	struct weston_view *view;
 	struct shell_surface *shsurf = get_shell_surface(surface);
@@ -2680,6 +2680,7 @@ shell_backend_request_window_move(struct weston_surface *surface, int x, int y)
 
 	assert(!shsurf->snapped.is_maximized_requested);
 	weston_view_set_position(view, x, y);
+	//TODO: support window resize (width x height)
 }
 
 static void


### PR DESCRIPTION
This is to remove legacy to_weston_x/to_weston_y macros for HI-DPI. This change alone does not enable window snap feature yet.