### PR TITLE
use wrapper function for reading config for RDP-backend

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -2200,12 +2200,8 @@ rdp_backend_create(struct weston_compositor *compositor,
 	}
 	rdp_debug_clipboard(b, "RDP backend: WESTON_RDP_DEBUG_CLIPBOARD_LEVEL: %d\n", b->debugClipboardLevel);
 
-	b->rdp_monitor_refresh_rate = rdp_read_config_int("WESTON_RDP_MONITOR_REFRESH_RATE", 0);
-	if (b->rdp_monitor_refresh_rate == 0) {
-		b->rdp_monitor_refresh_rate = RDP_MODE_FREQ;
-	} else {
-		b->rdp_monitor_refresh_rate *= 1000;
-	}
+	b->rdp_monitor_refresh_rate = rdp_read_config_int("WESTON_RDP_MONITOR_REFRESH_RATE", RDP_MODE_FREQ);
+	b->rdp_monitor_refresh_rate *= 1000;
 	rdp_debug(b, "RDP backend: WESTON_RDP_MONITOR_REFRESH_RATE: %d\n", b->rdp_monitor_refresh_rate);
 
 	clock_getres(CLOCK_MONOTONIC, &ts);

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -405,6 +405,8 @@ void rdp_id_manager_free_id(struct rdp_id_manager *id_manager, UINT32 id);
 void dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* title);
 bool rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
 void rdp_defer_rdp_task_done(RdpPeerContext *peerCtx);
+bool rdp_read_config_bool(char *config_name, bool default_value);
+int rdp_read_config_int(char *config_name, int default_value);
 
 // rdprail.c
 int rdp_rail_backend_create(struct rdp_backend *b);

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -64,7 +64,7 @@
 #include "shared/timespec-util.h"
 
 #define MAX_FREERDP_FDS 32
-#define RDP_MODE_FREQ 60 * 1000
+#define RDP_MODE_FREQ 60 // Hz
 #define RDP_MAX_MONITOR 16 // RDP max monitors.
 
 #define DEFAULT_PIXEL_FORMAT PIXEL_FORMAT_BGRA32

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -131,6 +131,7 @@ struct rdp_backend {
 	struct wl_listener create_window_listener;
 
 	bool enable_window_zorder_sync;
+	bool enable_window_snap_arrange;
 
 	bool keep_display_power_by_screenupdate;
 

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -2697,8 +2697,9 @@ rdp_rail_peer_activate(freerdp_peer* client)
 		RAIL_HANDSHAKE_EX_ORDER handshakeEx = {};
 		UINT32 railHandshakeFlags =
 			(TS_RAIL_ORDER_HANDSHAKEEX_FLAGS_HIDEF
-			 | TS_RAIL_ORDER_HANDSHAKE_EX_FLAGS_EXTENDED_SPI_SUPPORTED
-			/* | TS_RAIL_ORDER_HANDSHAKE_EX_FLAGS_SNAP_ARRANGE_SUPPORTED */);
+			 | TS_RAIL_ORDER_HANDSHAKE_EX_FLAGS_EXTENDED_SPI_SUPPORTED);
+		if (b->enable_window_snap_arrange)
+			railHandshakeFlags |= TS_RAIL_ORDER_HANDSHAKE_EX_FLAGS_SNAP_ARRANGE_SUPPORTED;
 		handshakeEx.buildNumber = 0;
 		handshakeEx.railHandshakeFlags = railHandshakeFlags;
 		if (peerCtx->rail_server_context->ServerHandshakeEx(peerCtx->rail_server_context, &handshakeEx) != CHANNEL_RC_OK)
@@ -4107,6 +4108,9 @@ rdp_rail_backend_create(struct rdp_backend *b)
 
 	b->enable_window_zorder_sync = rdp_read_config_bool("WESTON_RDP_WINDOW_ZORDER_SYNC", true);
 	rdp_debug(b, "RDP backend: window_zorder_sync = %d\n", b->enable_window_zorder_sync);
+
+	b->enable_window_snap_arrange = rdp_read_config_bool("WESTON_RDP_WINDOW_SNAP_ARRANGE", false);
+	rdp_debug(b, "RDP backend: window_snap_arrange = %d\n", b->enable_window_snap_arrange);
 
 	b->keep_display_power_by_screenupdate = rdp_read_config_bool("WESTON_RDP_DISPLAY_POWER_BY_SCREENUPDATE", false);
 	rdp_debug(b, "RDP backend: display_power_by_screenupdate = %d\n", b->keep_display_power_by_screenupdate);

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -397,3 +397,37 @@ rdp_defer_rdp_task_done(RdpPeerContext *peerCtx)
 	eventfd_read(peerCtx->loop_event_source_fd, &dummy);
 }
 
+bool
+rdp_read_config_bool(char *config_name, bool default_value)
+{
+	char *s;
+
+	s = getenv(config_name);
+	if (s) {
+		if (strcmp(s, "true") == 0)
+			return true;
+		else if (strcmp(s, "false") == 0)
+			return false;
+		else if (strcmp(s, "1") == 0)
+			return true;
+		else if (strcmp(s, "0") == 0)
+			return false;
+	}
+
+	return default_value;
+}
+
+int
+rdp_read_config_int(char *config_name, int default_value)
+{
+	char *s;
+	int i;
+
+	s = getenv(config_name);
+	if (s) {
+		if (safe_strtoint(s, &i))
+			return i;
+	}
+
+	return default_value;
+}


### PR DESCRIPTION
use wrapper function for reading config for RDP-backend. this allows certain flexibility later, if there is need for different way to read configuration for RDP-backend.