### PR TITLE
refactor dispatching task to display loop for multithreading-safe

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -850,7 +850,6 @@ rdp_peer_context_new(freerdp_peer* client, RdpPeerContext* context)
 
 	context->loop_task_event_source_fd = -1;
 	context->loop_task_event_source = NULL;
-	context->loop_task_list_mutex_initialized = false;
 	wl_list_init(&context->loop_task_list);
 
 	context->rfx_context = rfx_context_new(TRUE);
@@ -1945,10 +1944,10 @@ rdp_peer_init(freerdp_peer *client, struct rdp_backend *b)
 		peerCtx->events[i] = 0;
 
 	if (!rdp_initialize_dispatch_task_event_source(peerCtx))
-		goto error_peer_initialize;
+		goto error_dispatch_initialize;
 
 	if (!rdp_rail_peer_init(client, peerCtx))
-		goto error_peer_initialize;
+		goto error_rail_initialize;
 
 	/* This tracks the single peer connected. This field only used for RAIL mode
 	   and, with RAIL mode, there can be only one peer per backend, and that
@@ -1962,8 +1961,10 @@ rdp_peer_init(freerdp_peer *client, struct rdp_backend *b)
 		wl_list_insert(&b->output_default->peers, &peerCtx->item.link);
 	return 0;
 
-error_peer_initialize:
+error_rail_initialize:
 	rdp_destroy_dispatch_task_event_source(peerCtx);
+
+error_dispatch_initialize:
 	for (i = 0; i < ARRAY_LENGTH(peerCtx->events); i++) {
 		if (peerCtx->events[i]) {
 			wl_event_source_remove(peerCtx->events[i]);

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -848,7 +848,10 @@ rdp_peer_context_new(freerdp_peer* client, RdpPeerContext* context)
 	context->item.peer = client;
 	context->item.flags = RDP_PEER_OUTPUT_ENABLED;
 
-	context->loop_event_source_fd = -1;
+	context->loop_task_event_source_fd = -1;
+	context->loop_task_event_source = NULL;
+	context->loop_task_list_mutex_initialized = false;
+	wl_list_init(&context->loop_task_list);
 
 	context->rfx_context = rfx_context_new(TRUE);
 	if (!context->rfx_context)
@@ -886,9 +889,6 @@ rdp_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 
 	wl_list_remove(&context->item.link);
 
-	if (context->loop_event_source_fd != -1)
-		close(context->loop_event_source_fd);
-
 	for (i = 0; i < ARRAY_LENGTH(context->events); i++) {
 		if (context->events[i])
 			wl_event_source_remove(context->events[i]);
@@ -906,6 +906,8 @@ rdp_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 
 	if (context->vcm)
 		WTSCloseServer(context->vcm);
+
+	rdp_destroy_dispatch_task_event_source(context);
 
 	/* clear the peer, in RAIL mode, this allows new peer to connect */
 	if (context->rdpBackend->rdp_peer == client)
@@ -1942,8 +1944,7 @@ rdp_peer_init(freerdp_peer *client, struct rdp_backend *b)
 	for ( ; i < ARRAY_LENGTH(peerCtx->events); i++)
 		peerCtx->events[i] = 0;
 
-	peerCtx->loop_event_source_fd = eventfd(0, EFD_SEMAPHORE | EFD_CLOEXEC);
-	if (peerCtx->loop_event_source_fd == -1)
+	if (!rdp_initialize_dispatch_task_event_source(peerCtx))
 		goto error_peer_initialize;
 
 	if (!rdp_rail_peer_init(client, peerCtx))
@@ -1962,10 +1963,7 @@ rdp_peer_init(freerdp_peer *client, struct rdp_backend *b)
 	return 0;
 
 error_peer_initialize:
-	if (peerCtx->loop_event_source_fd != -1) {
-		close(peerCtx->loop_event_source_fd);
-		peerCtx->loop_event_source_fd = -1;
-	}
+	rdp_destroy_dispatch_task_event_source(peerCtx);
 	for (i = 0; i < ARRAY_LENGTH(peerCtx->events); i++) {
 		if (peerCtx->events[i]) {
 			wl_event_source_remove(peerCtx->events[i]);

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -261,7 +261,6 @@ struct rdp_peer_context {
 	// list of outstanding event_source sent from FreeRDP thread to display loop.
 	int loop_task_event_source_fd;
 	struct wl_event_source *loop_task_event_source;
-	bool loop_task_list_mutex_initialized;
 	pthread_mutex_t loop_task_list_mutex;
 	struct wl_list loop_task_list; // struct rdp_loop_task::link
 

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -84,11 +84,6 @@ struct rdp_id_manager {
 	struct hash_table *hash_table;
 };
 
-struct rdp_loop_event_source {
-	struct wl_list link;
-	struct wl_event_source *event_source;
-};
-
 struct rdp_backend {
 	struct weston_backend base;
 	struct weston_compositor *compositor;
@@ -262,10 +257,14 @@ struct rdp_peer_context {
 	struct wl_client *clientExec;
 	struct wl_listener clientExec_destroy_listener;
 	struct weston_surface *cursorSurface;
+
 	// list of outstanding event_source sent from FreeRDP thread to display loop.
-	int loop_event_source_fd;
-	pthread_mutex_t loop_event_source_list_mutex;
-	struct wl_list loop_event_source_list;
+	int loop_task_event_source_fd;
+	struct wl_event_source *loop_task_event_source;
+	bool loop_task_list_mutex_initialized;
+	pthread_mutex_t loop_task_list_mutex;
+	struct wl_list loop_task_list; // struct rdp_loop_task::link
+
 	// RAIL power management.
 	struct wl_listener idle_listener;
 	struct wl_listener wake_listener;
@@ -314,14 +313,18 @@ struct rdp_peer_context {
 	struct rdp_clipboard_data_source* clipboard_inflight_client_data_source;
 
 	struct wl_listener clipboard_selection_listener;
-	struct wl_event_source *clipboard_data_request_event_source;
-	UINT32 clipboard_last_requested_format_index;
 
 	// Application List support
 	BOOL isAppListEnabled;
 };
 
 typedef struct rdp_peer_context RdpPeerContext;
+
+struct rdp_loop_task {
+	struct wl_list link;
+	RdpPeerContext *peerCtx;
+	wl_event_loop_fd_func_t func;
+};
 
 #define RDP_RAIL_MARKER_WINDOW_ID  0xFFFFFFFE
 #define RDP_RAIL_DESKTOP_WINDOW_ID 0xFFFFFFFF
@@ -410,6 +413,10 @@ void rdp_id_manager_free_id(struct rdp_id_manager *id_manager, UINT32 id);
 void dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* title);
 bool rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
 void rdp_defer_rdp_task_done(RdpPeerContext *peerCtx);
+bool rdp_event_loop_add_fd(struct wl_event_loop *loop, int fd, uint32_t mask, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
+void rdp_dispatch_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, struct rdp_loop_task *task);
+bool rdp_initialize_dispatch_task_event_source(RdpPeerContext *peerCtx);
+void rdp_destroy_dispatch_task_event_source(RdpPeerContext *peerCtx);
 
 // rdprail.c
 int rdp_rail_backend_create(struct rdp_backend *b, struct weston_rdp_backend_config *config);

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -319,10 +319,12 @@ struct rdp_peer_context {
 
 typedef struct rdp_peer_context RdpPeerContext;
 
+typedef void (*rdp_loop_task_func_t)(bool freeOnly, void *data);
+
 struct rdp_loop_task {
 	struct wl_list link;
 	RdpPeerContext *peerCtx;
-	wl_event_loop_fd_func_t func;
+	rdp_loop_task_func_t func;
 };
 
 #define RDP_RAIL_MARKER_WINDOW_ID  0xFFFFFFFE
@@ -413,7 +415,7 @@ void dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* ti
 bool rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
 void rdp_defer_rdp_task_done(RdpPeerContext *peerCtx);
 bool rdp_event_loop_add_fd(struct wl_event_loop *loop, int fd, uint32_t mask, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
-void rdp_dispatch_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, struct rdp_loop_task *task);
+void rdp_dispatch_task_to_display_loop(RdpPeerContext *peerCtx, rdp_loop_task_func_t func, struct rdp_loop_task *task);
 bool rdp_initialize_dispatch_task_event_source(RdpPeerContext *peerCtx);
 void rdp_destroy_dispatch_task_event_source(RdpPeerContext *peerCtx);
 

--- a/libweston/backend-rdp/rdpclip.c
+++ b/libweston/backend-rdp/rdpclip.c
@@ -106,8 +106,8 @@ enum rdp_clipboard_data_source_state {
 
 struct rdp_clipboard_data_source {
 	struct weston_data_source base;
+	struct rdp_loop_task task_base;
 	struct wl_event_source *transfer_event_source; /* used for read/write with pipe */
-	struct wl_event_source *defer_event_source; /* used for defer task to display loop */
 	struct wl_array data_contents;
 	void *context;
 	int refcount;
@@ -121,6 +121,12 @@ struct rdp_clipboard_data_source {
 	BOOL is_data_processed;
 	BOOL is_canceled;
 	UINT32 client_format_id_table[RDP_NUM_CLIPBOARD_FORMATS];
+};
+
+struct rdp_clipboard_data_request {
+	struct rdp_loop_task task_base;
+	RdpPeerContext *peerCtx; 
+	UINT32 requested_format_index;
 };
 
 static char *
@@ -714,13 +720,6 @@ clipboard_data_source_unref(struct rdp_clipboard_data_source *source)
 		wl_event_source_remove(source->transfer_event_source);
 	}
 
-	if (source->defer_event_source) {
-		rdp_defer_rdp_task_done(peerCtx);
-		/* removing event source must be done from wayland display thread */
-		ASSERT_COMPOSITOR_THREAD(b);
-		wl_event_source_remove(source->defer_event_source);
-	}
-
 	if (source->data_source_fd != -1) {
 		ASSERT_COMPOSITOR_THREAD(b);
 		close(source->data_source_fd);
@@ -764,10 +763,6 @@ clipboard_client_send_format_data_response(RdpPeerContext *peerCtx, struct rdp_c
 	peerCtx->clipboard_server_context->ServerFormatDataResponse(peerCtx->clipboard_server_context, &formatDataResponse);
 	/* if here failed to send response, what can we do ? */
 
-	/* now client can send new data request */
-	assert(peerCtx->clipboard_data_request_event_source == RDP_INVALID_EVENT_SOURCE);
-	peerCtx->clipboard_data_request_event_source = NULL;
-
 	return 0;
 }
 
@@ -792,10 +787,6 @@ clipboard_client_send_format_data_response_fail(RdpPeerContext *peerCtx, struct 
 	formatDataResponse.requestedFormatData = NULL;
 	peerCtx->clipboard_server_context->ServerFormatDataResponse(peerCtx->clipboard_server_context, &formatDataResponse);
 	/* if here failed to send response, what can we do ? */
-
-	/* now client can send new data request */
-	assert(peerCtx->clipboard_data_request_event_source == RDP_INVALID_EVENT_SOURCE);
-	peerCtx->clipboard_data_request_event_source = NULL;
 
 	return 0;
 }
@@ -1002,12 +993,10 @@ clipboard_data_source_write(int fd, uint32_t mask, void *arg)
 				source->inflight_data_to_write = data_to_write;
 				source->inflight_data_size = data_size;
 				source->inflight_write_count++;
-				source->transfer_event_source =
-					wl_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
-							clipboard_data_source_write, source);
-				if (!source->transfer_event_source) {
+				if (!rdp_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
+					clipboard_data_source_write, source, &source->transfer_event_source)) {
 					source->state = RDP_CLIPBOARD_SOURCE_FAILED;
-					rdp_debug_clipboard_error(b, "RDP %s (%p:%s) wl_event_loop_add_fd failed\n",
+					rdp_debug_clipboard_error(b, "RDP %s (%p:%s) rdp_event_loop_add_fd failed\n",
 						__func__, source, clipboard_data_source_state_to_string(source));
 					break;
 				}
@@ -1123,12 +1112,10 @@ clipboard_data_source_send(struct weston_data_source *base,
 				__func__, source, clipboard_data_source_state_to_string(source), mime_type, index,
 				source->client_format_id_table[index],
 				clipboard_format_id_to_string(source->client_format_id_table[index], false));
-			source->transfer_event_source =
-				wl_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
-						clipboard_data_source_write, source);
-			if (!source->transfer_event_source) {
+			if (!rdp_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
+				clipboard_data_source_write, source, &source->transfer_event_source)) {
 				source->state = RDP_CLIPBOARD_SOURCE_FAILED;
-				rdp_debug_clipboard_error(b, "RDP %s (%p:%s) wl_event_loop_add_fd failed\n",
+				rdp_debug_clipboard_error(b, "RDP %s (%p:%s) rdp_event_loop_add_fd failed\n",
 					__func__, source, clipboard_data_source_state_to_string(source));
 				goto error_return_unref_source;
 			}
@@ -1229,7 +1216,7 @@ clipboard_data_source_cancel(struct weston_data_source *base)
 static int
 clipboard_data_source_publish(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_clipboard_data_source *source = (struct rdp_clipboard_data_source *)arg;
+	struct rdp_clipboard_data_source *source = wl_container_of(arg, source, task_base);
 	freerdp_peer *client = (freerdp_peer*)source->context;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
 	struct rdp_backend *b = peerCtx->rdpBackend;
@@ -1240,24 +1227,23 @@ clipboard_data_source_publish(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	rdp_defer_rdp_task_done(peerCtx);
-	assert(source->defer_event_source);
-	wl_event_source_remove(source->defer_event_source);
-	source->defer_event_source = NULL;
-
 	/* here is going to publish new data, if previous data from client is still referenced,
 	   unref it after selection */
 	source_prev = peerCtx->clipboard_client_data_source;
-	peerCtx->clipboard_client_data_source = source;
+	if (fd >= 0) {
+		peerCtx->clipboard_client_data_source = source;
+		source->transfer_event_source = NULL;
+		source->base.accept = clipboard_data_source_accept;
+		source->base.send = clipboard_data_source_send;
+		source->base.cancel = clipboard_data_source_cancel;
+		source->state = RDP_CLIPBOARD_SOURCE_PUBLISHED;
+		weston_seat_set_selection(peerCtx->item.seat, &source->base,
+					wl_display_next_serial(b->compositor->wl_display));
 
-	source->transfer_event_source = NULL;
-	source->base.accept = clipboard_data_source_accept;
-	source->base.send = clipboard_data_source_send;
-	source->base.cancel = clipboard_data_source_cancel;
-	source->state = RDP_CLIPBOARD_SOURCE_PUBLISHED;
-	weston_seat_set_selection(peerCtx->item.seat, &source->base,
-				wl_display_next_serial(b->compositor->wl_display));
-
+	} else {
+		peerCtx->clipboard_client_data_source = NULL;
+		clipboard_data_source_unref(source);
+	}
 	if (source_prev)
 		clipboard_data_source_unref(source_prev);
 
@@ -1268,7 +1254,8 @@ clipboard_data_source_publish(int fd, uint32_t mask, void *arg)
 static int
 clipboard_data_source_request(int fd, uint32_t mask, void *arg)
 {
-	RdpPeerContext *peerCtx = (RdpPeerContext *)arg;
+	struct rdp_clipboard_data_request *request = wl_container_of(arg, request, task_base);
+	RdpPeerContext *peerCtx = request->peerCtx;
 	struct rdp_backend *b = peerCtx->rdpBackend;
 	struct weston_seat *seat = peerCtx->item.seat;
 	struct weston_data_source *selection_data_source = seat->selection_data_source;
@@ -1281,14 +1268,10 @@ clipboard_data_source_request(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	rdp_defer_rdp_task_done(peerCtx);
-	assert(peerCtx->clipboard_data_request_event_source);
-	assert(peerCtx->clipboard_data_request_event_source != RDP_INVALID_EVENT_SOURCE);
-	wl_event_source_remove(peerCtx->clipboard_data_request_event_source);
-	/* set to invalid, so it still validate incoming request, but won't free event source at error. */
-	peerCtx->clipboard_data_request_event_source = RDP_INVALID_EVENT_SOURCE;
+	if (fd < 0)
+		goto error_exit_free_request;
 
-	index = peerCtx->clipboard_last_requested_format_index;
+	index = request->requested_format_index;
 	assert(index >= 0 && index < (int)RDP_NUM_CLIPBOARD_FORMATS);
 	requested_mime_type = clipboard_supported_formats[index].mime_type;
 	rdp_debug_clipboard(b, "RDP %s (base:%p) requested mime type:\"%s\"\n",
@@ -1342,15 +1325,15 @@ clipboard_data_source_request(int fd, uint32_t mask, void *arg)
 	/* p[1] should be closed by data source */
 
 	/* wait until data is ready on pipe */
-	source->transfer_event_source =
-		wl_event_loop_add_fd(loop, p[0], WL_EVENT_READABLE,
-					clipboard_data_source_read, source);
-	if (!source->transfer_event_source) {
+	if (!rdp_event_loop_add_fd(loop, p[0], WL_EVENT_READABLE,
+		clipboard_data_source_read, source, &source->transfer_event_source)) {
 		source->state = RDP_CLIPBOARD_SOURCE_FAILED;
-		rdp_debug_clipboard_error(b, "RDP %s (%p:%s) wl_event_loop_add_fd failed.\n",
+		rdp_debug_clipboard_error(b, "RDP %s (%p:%s) rdp_event_loop_add_fd failed.\n",
 			__func__, source, clipboard_data_source_state_to_string(source));
 		goto error_exit_free_source;
 	}
+
+	free(request);
 
 	return 0;
 
@@ -1360,6 +1343,9 @@ error_exit_free_source:
 
 error_exit_response_fail:
 	clipboard_client_send_format_data_response_fail(peerCtx, NULL);
+
+error_exit_free_request:
+	free(request);
 
 	return 0;
 }
@@ -1555,15 +1541,8 @@ clipboard_client_format_list(CliprdrServerContext* context, const CLIPRDR_FORMAT
 		}
 
 		source->state = RDP_CLIPBOARD_SOURCE_FORMATLIST_READY;
-		if (rdp_defer_rdp_task_to_display_loop(
-				peerCtx, clipboard_data_source_publish,
-				source, &source->defer_event_source)) {
-			isPublished = TRUE;
-		} else {
-			source->state = RDP_CLIPBOARD_SOURCE_FAILED;
-			rdp_debug_clipboard_error(b, "Client: %s (%p:%s) rdp_defer_rdp_task_to_display_loop failed\n",
-				__func__, source, clipboard_data_source_state_to_string(source));
-		}
+		rdp_dispatch_task_to_display_loop(peerCtx, clipboard_data_source_publish, &source->task_base);
+		isPublished = TRUE;
 	}
 
 	CLIPRDR_FORMAT_LIST_RESPONSE formatListResponse = {};
@@ -1637,12 +1616,10 @@ clipboard_client_format_data_response(CliprdrServerContext* context, const CLIPR
 			source->data_response_fail_count);
 
 		assert(source->transfer_event_source == NULL);
-		source->transfer_event_source =
-			wl_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
-				Success ? clipboard_data_source_write : clipboard_data_source_fail, source);
-		if (!source->transfer_event_source) {
+		if (!rdp_event_loop_add_fd(loop, source->data_source_fd, WL_EVENT_WRITABLE,
+			Success ? clipboard_data_source_write : clipboard_data_source_fail, source, &source->transfer_event_source)) {
 			source->state = RDP_CLIPBOARD_SOURCE_FAILED;
-			rdp_debug_clipboard_error(b, "Client: %s (%p:%s) wl_event_loop_add_fd failed\n",
+			rdp_debug_clipboard_error(b, "Client: %s (%p:%s) rdp_event_loop_add_fd failed\n",
 				__func__, source, clipboard_data_source_state_to_string(source));
 			return -1;
 		}
@@ -1673,6 +1650,7 @@ clipboard_client_format_data_request(CliprdrServerContext* context, const CLIPRD
 	freerdp_peer *client = (freerdp_peer*)context->custom;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
 	struct rdp_backend *b = peerCtx->rdpBackend;
+	struct rdp_clipboard_data_request *request;
 	int index;
 
 	rdp_debug_clipboard(b, "Client: %s requestedFormatId:%d - %s\n",
@@ -1681,27 +1659,21 @@ clipboard_client_format_data_request(CliprdrServerContext* context, const CLIPRD
 
 	ASSERT_NOT_COMPOSITOR_THREAD(b);
 
-	if (peerCtx->clipboard_data_request_event_source) {
-		rdp_debug_clipboard_error(b, "Client: %s (outstanding event:%p) client requests data while server hasn't responded previous request yet. protocol error.\n",
-			__func__, peerCtx->clipboard_data_request_event_source);
-		return -1;
-	}
-
 	/* Make sure clients requested the format we knew */
 	index = clipboard_find_supported_format_by_format_id(formatDataRequest->requestedFormatId);
 	if (index >= 0) {
-		peerCtx->clipboard_last_requested_format_index = index;
-		if (!rdp_defer_rdp_task_to_display_loop(
-			peerCtx, clipboard_data_source_request,
-			peerCtx, &peerCtx->clipboard_data_request_event_source)) {
-			rdp_debug_clipboard_error(b, "Client: %s rdp_defer_rdp_task_to_display_loop failed\n", __func__);
+		request = zalloc(sizeof(*request));
+		if (!request) {
+			rdp_debug_clipboard_error(b, "zalloc failed\n", __func__);
 			goto error_return;
 		}
+		request->peerCtx = peerCtx;
+		request->requested_format_index = index;
+		rdp_dispatch_task_to_display_loop(peerCtx, clipboard_data_source_request, &request->task_base);
 	} else {
 		rdp_debug_clipboard_error(b, "Client: %s client requests data format the server never reported in format list response. protocol error.\n", __func__);
-		return -1;
+		goto error_return;
 	}
-
 	return 0;
 
 error_return:
@@ -1775,18 +1747,13 @@ rdp_clipboard_destroy(RdpPeerContext *peerCtx)
 		wl_list_remove(&peerCtx->clipboard_selection_listener.link);
 		peerCtx->clipboard_selection_listener.notify = NULL;
 	}
-	if (peerCtx->clipboard_data_request_event_source &&
-		peerCtx->clipboard_data_request_event_source != RDP_INVALID_EVENT_SOURCE) {
-		rdp_defer_rdp_task_done(peerCtx);
-		wl_event_source_remove(peerCtx->clipboard_data_request_event_source);
-		peerCtx->clipboard_data_request_event_source = NULL;
-	}
 
 	if (peerCtx->clipboard_inflight_client_data_source) {
 		data_source = peerCtx->clipboard_inflight_client_data_source;
 		peerCtx->clipboard_inflight_client_data_source = NULL;
 		clipboard_data_source_unref(data_source);
 	}
+
 	if (peerCtx->clipboard_client_data_source) {
 		data_source = peerCtx->clipboard_client_data_source;
 		peerCtx->clipboard_client_data_source = NULL;

--- a/libweston/backend-rdp/rdpdisp.c
+++ b/libweston/backend-rdp/rdpdisp.c
@@ -610,8 +610,8 @@ struct disp_schedule_monitor_layout_change_data {
 	DISPLAY_CONTROL_MONITOR_LAYOUT_PDU displayControl;
 };
 
-static int
-disp_monitor_layout_change_callback(int fd, uint32_t mask, void* dataIn)
+static void
+disp_monitor_layout_change_callback(bool freeOnly, void* dataIn)
 {
 	struct disp_schedule_monitor_layout_change_data *data = wl_container_of(dataIn, data, _base);
 	DispServerContext* context = data->context;
@@ -620,12 +620,12 @@ disp_monitor_layout_change_callback(int fd, uint32_t mask, void* dataIn)
 
 	ASSERT_COMPOSITOR_THREAD(peerCtx->rdpBackend);
 
-	if (fd >= 0)
+	if (!freeOnly)
 		disp_monitor_layout_change(context, &data->displayControl);
 
 	free(data);
 
-	return 0;
+	return;
 }
 
 UINT

--- a/libweston/backend-rdp/rdpdisp.c
+++ b/libweston/backend-rdp/rdpdisp.c
@@ -605,7 +605,7 @@ Exit:
 }
 
 struct disp_schedule_monitor_layout_change_data {
-	struct rdp_loop_event_source _base_event_source;
+	struct rdp_loop_task _base;
 	DispServerContext* context;
 	DISPLAY_CONTROL_MONITOR_LAYOUT_PDU displayControl;
 };
@@ -613,22 +613,17 @@ struct disp_schedule_monitor_layout_change_data {
 static int
 disp_monitor_layout_change_callback(int fd, uint32_t mask, void* dataIn)
 {
-	struct disp_schedule_monitor_layout_change_data *data = (struct disp_schedule_monitor_layout_change_data *)dataIn;
+	struct disp_schedule_monitor_layout_change_data *data = wl_container_of(dataIn, data, _base);
 	DispServerContext* context = data->context;
 	freerdp_peer *client = (freerdp_peer*)context->custom;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
 
 	ASSERT_COMPOSITOR_THREAD(peerCtx->rdpBackend);
 
-	rdp_defer_rdp_task_done(peerCtx);
-	assert(data->_base_event_source.event_source);
-	wl_event_source_remove(data->_base_event_source.event_source);
-	pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
-	wl_list_remove(&data->_base_event_source.link);
-	pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);
+	if (fd >= 0)
+		disp_monitor_layout_change(context, &data->displayControl);
 
-	disp_monitor_layout_change(context, &data->displayControl);
-	free(dataIn);
+	free(data);
 
 	return 0;
 }
@@ -658,18 +653,7 @@ disp_client_monitor_layout_change(DispServerContext* context, const DISPLAY_CONT
 	memcpy(data->displayControl.Monitors, displayControl->Monitors,
 		sizeof(DISPLAY_CONTROL_MONITOR_LAYOUT) * displayControl->NumMonitors);
 
-	pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
-	wl_list_insert(&peerCtx->loop_event_source_list, &data->_base_event_source.link);
-	pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);
-	if (!rdp_defer_rdp_task_to_display_loop(
-			peerCtx, disp_monitor_layout_change_callback,
-			data, &data->_base_event_source.event_source)) {
-		pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex);
-		wl_list_remove(&data->_base_event_source.link);
-		pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex);
-		free(data);
-		return ERROR_INTERNAL_ERROR;  
-	}
+	rdp_dispatch_task_to_display_loop(peerCtx, disp_monitor_layout_change_callback, &data->_base);
 
 	return 0;
 }

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -55,8 +55,8 @@ static void rdp_rail_destroy_window(struct wl_listener *listener, void *data);
 static void rdp_rail_schedule_update_window(struct wl_listener *listener, void *data);
 static void rdp_rail_dump_window_label(struct weston_surface *surface, char *label, uint32_t label_size);
 
-struct rdp_dispatch_data {
-	struct rdp_loop_event_source _base_event_source;
+struct rdp_rail_dispatch_data {
+	struct rdp_loop_task task_base;
 	freerdp_peer *client;
 	union {
 		RAIL_SYSPARAM_ORDER u_sysParam;
@@ -78,24 +78,13 @@ struct rdp_dispatch_data {
 		freerdp_peer *client = (freerdp_peer*)(context)->custom; \
 		RdpPeerContext *peerCtx = (RdpPeerContext *)client->context; \
 		struct rdp_backend *b = peerCtx->rdpBackend; \
-		struct rdp_dispatch_data *dispatch_data; \
-		dispatch_data = (struct rdp_dispatch_data *)malloc(sizeof(*dispatch_data)); \
+		struct rdp_rail_dispatch_data *dispatch_data; \
+		dispatch_data = (struct rdp_rail_dispatch_data *)malloc(sizeof(*dispatch_data)); \
 		if (dispatch_data) { \
 			ASSERT_NOT_COMPOSITOR_THREAD(b); \
 			dispatch_data->client = client; \
 			dispatch_data->u_##arg_type = *(arg); \
-			pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex); \
-			wl_list_insert(&peerCtx->loop_event_source_list, &dispatch_data->_base_event_source.link); \
-			pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex); \
-			if (!rdp_defer_rdp_task_to_display_loop( \
-				peerCtx, callback, \
-				dispatch_data, &dispatch_data->_base_event_source.event_source)) { \
-				rdp_debug_error(b, "%s: rdp_queue_deferred_task failed\n", __func__); \
-				pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex); \
-				wl_list_remove(&dispatch_data->_base_event_source.link); \
-				pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex); \
-				free(dispatch_data); \
-			} \
+			rdp_dispatch_task_to_display_loop(peerCtx, callback, &dispatch_data->task_base); \
 		} else { \
 			rdp_debug_error(b, "%s: malloc failed\n", __func__); \
 		} \
@@ -104,12 +93,6 @@ struct rdp_dispatch_data {
 #define RDP_DISPATCH_DISPLAY_LOOP_COMPLETED(peerCtx, dispatch_data) \
 	{ \
 		ASSERT_COMPOSITOR_THREAD(peerCtx->rdpBackend); \
-		rdp_defer_rdp_task_done(peerCtx); \
-		assert(dispatch_data->_base_event_source.event_source); \
-		wl_event_source_remove(dispatch_data->_base_event_source.event_source); \
-		pthread_mutex_lock(&peerCtx->loop_event_source_list_mutex); \
-		wl_list_remove(&dispatch_data->_base_event_source.link); \
-		pthread_mutex_unlock(&peerCtx->loop_event_source_list_mutex); \
 		free(dispatch_data); \
 		return 0; \
 	}
@@ -118,7 +101,7 @@ struct rdp_dispatch_data {
 static int
 applist_client_Caps_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RDPAPPLIST_CLIENT_CAPS_PDU* caps = &data->u_appListCaps;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -129,7 +112,8 @@ applist_client_Caps_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	if (b->rdprail_shell_api &&
+	if (fd >= 0 &&
+		b->rdprail_shell_api &&
 		b->rdprail_shell_api->start_app_list_update) {
 
 		strncpy(clientLanguageId, caps->clientLanguageId, RDPAPPLIST_LANG_SIZE);
@@ -182,7 +166,7 @@ rail_ClientExec_destroy(struct wl_listener *listener, void *data)
 static int
 rail_client_Exec_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_EXEC_ORDER* exec = &data->u_exec;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -199,7 +183,8 @@ rail_client_Exec_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(peerCtx->rdpBackend);
 
-	if (exec->RemoteApplicationProgram) {
+	if (fd >= 0 &&
+		exec->RemoteApplicationProgram) {
 		if (!utf8_string_to_rail_string(exec->RemoteApplicationProgram, &orderResult.exeOrFile))
 			goto send_result;
 
@@ -238,10 +223,13 @@ rail_client_Exec_callback(int fd, uint32_t mask, void *arg)
 	}
 
 send_result:
-	orderResult.flags = exec->flags;
-	orderResult.execResult = result;
-	orderResult.rawResult = 0;
-	peerCtx->rail_server_context->ServerExecResult(peerCtx->rail_server_context, &orderResult);
+
+	if (fd >= 0) {
+		orderResult.flags = exec->flags;
+		orderResult.execResult = result;
+		orderResult.rawResult = 0;
+		peerCtx->rail_server_context->ServerExecResult(peerCtx->rail_server_context, &orderResult);
+	}
 
 	if (orderResult.exeOrFile.string)
 		free(orderResult.exeOrFile.string);
@@ -296,7 +284,7 @@ Exit_Error:
 static int
 rail_client_Activate_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_ACTIVATE_ORDER* activate = &data->u_activate;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -307,7 +295,8 @@ rail_client_Activate_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	if (b->rdprail_shell_api &&
+	if (fd >= 0 &&
+		b->rdprail_shell_api &&
 		b->rdprail_shell_api->request_window_activate &&
 		b->rdprail_shell_context) {
 		if (activate->windowId && activate->enabled) {
@@ -331,7 +320,7 @@ rail_client_Activate(RailServerContext* context, const RAIL_ACTIVATE_ORDER* arg)
 static int
 rail_client_SnapArrange_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_SNAP_ARRANGE* snap = &data->u_snapArrange;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -349,7 +338,9 @@ rail_client_SnapArrange_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, snap->windowId);
+	surface = NULL;
+	if (fd >= 0)
+		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, snap->windowId);
 	if (surface) {
 		rail_state = (struct weston_surface_rail_state *)surface->backend_state;
 		if (b->rdprail_shell_api &&
@@ -385,7 +376,7 @@ rail_client_SnapArrange(RailServerContext* context, const RAIL_SNAP_ARRANGE* arg
 static int
 rail_client_WindowMove_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_WINDOW_MOVE_ORDER* windowMove = &data->u_windowMove;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -402,7 +393,9 @@ rail_client_WindowMove_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, windowMove->windowId);
+	surface = NULL;
+	if (fd >= 0)
+		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, windowMove->windowId);
 	if (surface) {
 		if (b->rdprail_shell_api &&
 			b->rdprail_shell_api->request_window_move) {
@@ -418,10 +411,9 @@ rail_client_WindowMove_callback(int fd, uint32_t mask, void *arg)
 				windowMoveRect.y,
 				windowMoveRect.width,
 				windowMoveRect.height);
+			rdp_debug(b, "Surface Size (%d, %d)\n", surface->width, surface->height);
 		}
 	}
-
-	rdp_debug(b, "Surface Size (%d, %d)\n", surface->width, surface->height);
 
 	RDP_DISPATCH_DISPLAY_LOOP_COMPLETED(peerCtx, data);
 }
@@ -436,7 +428,7 @@ rail_client_WindowMove(RailServerContext* context, const RAIL_WINDOW_MOVE_ORDER*
 static int
 rail_client_Syscommand_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_SYSCOMMAND_ORDER* syscommand = &data->u_sysCommand;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -445,7 +437,9 @@ rail_client_Syscommand_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, syscommand->windowId);
+	surface = NULL;
+	if (fd >= 0)
+		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, syscommand->windowId);
 	if (!surface) {
 		rdp_debug_error(b, "Client: ClientSyscommand: WindowId:0x%x is not found.\n", syscommand->windowId);
 		goto Exit;
@@ -511,7 +505,7 @@ rail_client_Syscommand(RailServerContext* context, const RAIL_SYSCOMMAND_ORDER* 
 static int
 rail_client_ClientSysparam_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_SYSPARAM_ORDER* sysparam = &data->u_sysParam;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -593,7 +587,8 @@ rail_client_ClientSysparam_callback(int fd, uint32_t mask, void *arg)
 	}
 
 	if (sysparam->params & SPI_MASK_SET_WORK_AREA) {
-		if (b->rdprail_shell_api &&
+		if (fd >= 0 &&
+			b->rdprail_shell_api &&
 			b->rdprail_shell_api->set_desktop_workarea) {
 			workareaRectClient.x = (INT32)(INT16)sysparam->workArea.left;
 			workareaRectClient.y = (INT32)(INT16)sysparam->workArea.top;
@@ -636,7 +631,7 @@ rail_client_ClientSysparam(RailServerContext* context, const RAIL_SYSPARAM_ORDER
 static int
 rail_client_ClientGetAppidReq_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_GET_APPID_REQ_ORDER* getAppidReq = &data->u_getAppidReq;
 	freerdp_peer *client = data->client;
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
@@ -652,7 +647,8 @@ rail_client_ClientGetAppidReq_callback(int fd, uint32_t mask, void *arg)
 
 	ASSERT_COMPOSITOR_THREAD(b);
 
-	if (b->rdprail_shell_api &&
+	if (fd >= 0 &&
+		b->rdprail_shell_api &&
 		b->rdprail_shell_api->get_window_app_id) {
 
 		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, getAppidReq->windowId);
@@ -814,7 +810,7 @@ languageGuid_to_string(const GUID *guid)
 static int
 rail_client_LanguageImeInfo_callback(int fd, uint32_t mask, void *arg)
 {
-	struct rdp_dispatch_data* data = (struct rdp_dispatch_data*)arg; 
+	struct rdp_rail_dispatch_data* data = wl_container_of(arg, data, task_base);
 	const RAIL_LANGUAGEIME_INFO_ORDER* languageImeInfo = &data->u_languageImeInfo;
 	freerdp_peer *client = data->client;
 	rdpSettings *settings = client->settings;
@@ -847,63 +843,65 @@ rail_client_LanguageImeInfo_callback(int fd, uint32_t mask, void *arg)
 			languageGuid_to_string(&languageImeInfo->ProfileGUID));
 	rdp_debug(b, "Client: LanguageImeInfo: KeyboardLayout: 0x%x\n", languageImeInfo->KeyboardLayout);
 
-	if (languageImeInfo->ProfileType == TF_PROFILETYPE_KEYBOARDLAYOUT) {
-		new_keyboard_layout = languageImeInfo->KeyboardLayout;
-	} else if (languageImeInfo->ProfileType == TF_PROFILETYPE_INPUTPROCESSOR) {
-		typedef struct _lang_GUID
-		{
-			UINT32 Data1;
-			UINT16 Data2;
-			UINT16 Data3;
-			BYTE Data4_0;
-			BYTE Data4_1;
-			BYTE Data4_2;
-			BYTE Data4_3;
-			BYTE Data4_4;
-			BYTE Data4_5;
-			BYTE Data4_6;
-			BYTE Data4_7;
-		} lang_GUID;
+	if (fd >= 0) {
+		if (languageImeInfo->ProfileType == TF_PROFILETYPE_KEYBOARDLAYOUT) {
+			new_keyboard_layout = languageImeInfo->KeyboardLayout;
+		} else if (languageImeInfo->ProfileType == TF_PROFILETYPE_INPUTPROCESSOR) {
+			typedef struct _lang_GUID
+			{
+				UINT32 Data1;
+				UINT16 Data2;
+				UINT16 Data3;
+				BYTE Data4_0;
+				BYTE Data4_1;
+				BYTE Data4_2;
+				BYTE Data4_3;
+				BYTE Data4_4;
+				BYTE Data4_5;
+				BYTE Data4_6;
+				BYTE Data4_7;
+			} lang_GUID;
 
-		static const lang_GUID c_GUID_JPNIME = GUID_MSIME_JPN;
-		static const lang_GUID c_GUID_KORIME = GUID_MSIME_KOR;
-		static const lang_GUID c_GUID_CHSIME = GUID_CHSIME;
-		static const lang_GUID c_GUID_CHTIME = GUID_CHTIME;
+			static const lang_GUID c_GUID_JPNIME = GUID_MSIME_JPN;
+			static const lang_GUID c_GUID_KORIME = GUID_MSIME_KOR;
+			static const lang_GUID c_GUID_CHSIME = GUID_CHSIME;
+			static const lang_GUID c_GUID_CHTIME = GUID_CHTIME;
 
-		RPC_STATUS rpc_status;
-		if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
-			(GUID *)&c_GUID_JPNIME, &rpc_status))
-			new_keyboard_layout = KBD_JAPANESE;
-		else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
-			(GUID *)&c_GUID_KORIME, &rpc_status))
-			new_keyboard_layout = KBD_KOREAN;
-		else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
-			(GUID *)&c_GUID_CHSIME, &rpc_status))
-			new_keyboard_layout = KBD_CHINESE_SIMPLIFIED_US;
-		else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
-			(GUID *)&c_GUID_CHTIME, &rpc_status))
-			new_keyboard_layout = KBD_CHINESE_TRADITIONAL_US;
-		else 
-			new_keyboard_layout = KBD_US;
-	}
-
-	if (new_keyboard_layout && (new_keyboard_layout != settings->KeyboardLayout)) {
-		convert_rdp_keyboard_to_xkb_rule_names(settings->KeyboardType,
-						       settings->KeyboardSubType,
-						       new_keyboard_layout,
-						       &xkbRuleNames);
-		if (xkbRuleNames.layout) {
-			keymap = xkb_keymap_new_from_names(b->compositor->xkb_context,
-							   &xkbRuleNames, 0);
-			if (keymap) {
-				weston_seat_update_keymap(peerCtx->item.seat, keymap);
-				xkb_keymap_unref(keymap);
-				settings->KeyboardLayout = new_keyboard_layout;
-			}
+			RPC_STATUS rpc_status;
+			if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
+				(GUID *)&c_GUID_JPNIME, &rpc_status))
+				new_keyboard_layout = KBD_JAPANESE;
+			else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
+				(GUID *)&c_GUID_KORIME, &rpc_status))
+				new_keyboard_layout = KBD_KOREAN;
+			else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
+				(GUID *)&c_GUID_CHSIME, &rpc_status))
+				new_keyboard_layout = KBD_CHINESE_SIMPLIFIED_US;
+			else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
+				(GUID *)&c_GUID_CHTIME, &rpc_status))
+				new_keyboard_layout = KBD_CHINESE_TRADITIONAL_US;
+			else 
+				new_keyboard_layout = KBD_US;
 		}
-		if (!keymap) {
-			rdp_debug_error(b, "%s: Failed to switch to kbd_layout:0x%x kbd_type:0x%x kbd_subType:0x%x\n",
-				__func__, new_keyboard_layout, settings->KeyboardType, settings->KeyboardSubType);
+
+		if (new_keyboard_layout && (new_keyboard_layout != settings->KeyboardLayout)) {
+			convert_rdp_keyboard_to_xkb_rule_names(settings->KeyboardType,
+							       settings->KeyboardSubType,
+							       new_keyboard_layout,
+							       &xkbRuleNames);
+			if (xkbRuleNames.layout) {
+				keymap = xkb_keymap_new_from_names(b->compositor->xkb_context,
+								   &xkbRuleNames, 0);
+				if (keymap) {
+					weston_seat_update_keymap(peerCtx->item.seat, keymap);
+					xkb_keymap_unref(keymap);
+					settings->KeyboardLayout = new_keyboard_layout;
+				}
+			}
+			if (!keymap) {
+				rdp_debug_error(b, "%s: Failed to switch to kbd_layout:0x%x kbd_type:0x%x kbd_subType:0x%x\n",
+					__func__, new_keyboard_layout, settings->KeyboardType, settings->KeyboardSubType);
+			}
 		}
 	}
 
@@ -3165,8 +3163,6 @@ rdp_rail_destroy_window_iter(void *element, void *data)
 void
 rdp_rail_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 {
-	struct rdp_loop_event_source *current, *next;
-
 	rdp_id_manager_for_each(&context->windowId, rdp_rail_destroy_window_iter, NULL);
 
 #ifdef HAVE_FREERDP_RDPAPPLIST_H
@@ -3203,14 +3199,6 @@ rdp_rail_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 		context->rail_server_context->Stop(context->rail_server_context);
 		rail_server_context_free(context->rail_server_context);
 	}
-
-	/* after stopping all FreeRDP server context, no more work to be queued, free anything remained */ 
-	wl_list_for_each_safe(current, next, &context->loop_event_source_list, link) {
-		wl_event_source_remove(current->event_source);
-		wl_list_remove(&current->link);
-		free(current);
-	}
-	pthread_mutex_destroy(&context->loop_event_source_list_mutex);
 
 	if (context->clientExec_destroy_listener.notify) {
 		wl_list_remove(&context->clientExec_destroy_listener.link);
@@ -3310,9 +3298,6 @@ rdp_rail_peer_init(freerdp_peer *client, RdpPeerContext *peerCtx)
 		goto error_return;
 	}
 #endif // HAVE_FREERDP_GFXREDIR_H
-
-	pthread_mutex_init(&peerCtx->loop_event_source_list_mutex, NULL);
-	wl_list_init(&peerCtx->loop_event_source_list);
 
 	peerCtx->currentFrameId = 0;
 	peerCtx->acknowledgedFrameId = 0;

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -364,38 +364,126 @@ dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* title)
 	fprintf(fp,"\n");
 }
 
-/* this function is ONLY used to defer the task from RDP thread,
-   to be performed at wayland display loop thread */
 bool
-rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source)
+rdp_event_loop_add_fd(struct wl_event_loop *loop, int fd, uint32_t mask, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source)
 {
-	assert(event_source);
-	*event_source = NULL;
-	if (peerCtx->vcm) {
-		struct rdp_backend *b = peerCtx->rdpBackend;
-		ASSERT_NOT_COMPOSITOR_THREAD(b);
-		struct wl_event_loop *loop = wl_display_get_event_loop(b->compositor->wl_display);
-		*event_source = wl_event_loop_add_fd(loop,
-					peerCtx->loop_event_source_fd,
-					WL_EVENT_READABLE,
-					func, data);
-		if (*event_source) {
-			eventfd_write(peerCtx->loop_event_source_fd, 1);
-			return true;
-		} else {
-			rdp_debug_error(b, "%s: wl_event_loop_add_idle failed\n", __func__);
-		}
-	} else {
-		/* RDP server is not opened, this must not be used */
-		assert(false);
-	}
-	return false;
+	*event_source = wl_event_loop_add_fd(loop, fd, 0, func, data);
+	if (!*event_source)
+		return false;
+
+	wl_event_source_fd_update(*event_source, mask);
+	return true;
 }
 
 void
-rdp_defer_rdp_task_done(RdpPeerContext *peerCtx)
+rdp_dispatch_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, struct rdp_loop_task *task)
 {
+	/* this function is ONLY used to queue the task from FreeRDP thread,
+	   and the task to be processed at wayland display loop thread. */
+	ASSERT_NOT_COMPOSITOR_THREAD(peerCtx->rdpBackend);
+
+	task->peerCtx = peerCtx;
+	task->func = func;
+
+	pthread_mutex_lock(&peerCtx->loop_task_list_mutex);
+	/* this inserts at head */
+	wl_list_insert(&peerCtx->loop_task_list, &task->link);
+	pthread_mutex_unlock(&peerCtx->loop_task_list_mutex);
+
+	eventfd_write(peerCtx->loop_task_event_source_fd, 1);
+}
+
+static int
+rdp_dispatch_task(int fd, uint32_t mask, void *arg)
+{
+	RdpPeerContext *peerCtx = (RdpPeerContext *)arg;
+	struct rdp_loop_task *task, *tmp;
 	eventfd_t dummy;
-	eventfd_read(peerCtx->loop_event_source_fd, &dummy);
+
+	/* this must be called back at wayland display loop thread */
+	ASSERT_COMPOSITOR_THREAD(peerCtx->rdpBackend);
+
+	eventfd_read(peerCtx->loop_task_event_source_fd, &dummy);
+
+	pthread_mutex_lock(&peerCtx->loop_task_list_mutex);
+	/* dequeue the first task which is at last, so use reverse. */
+	assert(!wl_list_empty(&peerCtx->loop_task_list));
+	wl_list_for_each_reverse_safe(task, tmp, &peerCtx->loop_task_list, link) {
+		wl_list_remove(&task->link);
+		break;
+	}
+	pthread_mutex_unlock(&peerCtx->loop_task_list_mutex);
+
+	/* Dispatch and task will be freed by caller. */
+	assert(fd >= 0);
+	return task->func(fd, mask, task);
+}
+
+bool
+rdp_initialize_dispatch_task_event_source(RdpPeerContext *peerCtx)
+{
+	struct rdp_backend *b = peerCtx->rdpBackend;
+	struct wl_event_loop *loop;
+
+	assert(peerCtx->loop_task_list_mutex_initialized == false);
+	if (pthread_mutex_init(&peerCtx->loop_task_list_mutex, NULL) == -1) {
+		rdp_debug_error(b, "%s: pthread_mutex_init failed. %s\n", __func__, strerror(errno));
+		return false;
+	}
+	peerCtx->loop_task_list_mutex_initialized = true;
+
+	assert(peerCtx->loop_task_event_source_fd == -1);
+	peerCtx->loop_task_event_source_fd = eventfd(0, EFD_SEMAPHORE | EFD_CLOEXEC);
+	if (peerCtx->loop_task_event_source_fd == -1) {
+		rdp_debug_error(b, "%s: eventfd(EFD_SEMAPHORE) failed. %s\n", __func__, strerror(errno));
+		return false;
+	}
+
+	assert(wl_list_empty(&peerCtx->loop_task_list));
+
+	loop = wl_display_get_event_loop(b->compositor->wl_display);
+	assert(peerCtx->loop_task_event_source == NULL);
+	if (!rdp_event_loop_add_fd(
+		loop, peerCtx->loop_task_event_source_fd, WL_EVENT_READABLE,
+		rdp_dispatch_task, peerCtx, &peerCtx->loop_task_event_source)) {
+		rdp_debug_error(b, "%s: rdp_event_loop_add_fd() failed\n", __func__);
+		close(peerCtx->loop_task_event_source_fd);
+		peerCtx->loop_task_event_source_fd = -1;
+		return false;
+	}
+
+	return true;
+}
+
+void
+rdp_destroy_dispatch_task_event_source(RdpPeerContext *peerCtx)
+{
+	struct rdp_loop_task *task, *tmp;
+
+	/* This function must be called all virtual channel thread at FreeRDP is terminated,
+	   that ensures no more incoming tasks. */
+
+	if (peerCtx->loop_task_event_source) {
+		wl_event_source_remove(peerCtx->loop_task_event_source);
+		peerCtx->loop_task_event_source = NULL;
+	}
+
+	wl_list_for_each_reverse_safe(task, tmp, &peerCtx->loop_task_list, link) {
+		wl_list_remove(&task->link);
+		/* inform caller task is not really scheduled prior to context destruction,
+		   inform them to clean them up. */
+		task->func(-1, 0, task);
+	}
+	assert(wl_list_empty(&peerCtx->loop_task_list));
+
+	if (peerCtx->loop_task_event_source_fd != -1) {
+		close(peerCtx->loop_task_event_source_fd);
+		peerCtx->loop_task_event_source_fd = -1;
+	}
+
+	if (peerCtx->loop_task_list_mutex_initialized) {
+		pthread_mutex_destroy(&peerCtx->loop_task_list_mutex);
+		peerCtx->loop_task_list_mutex_initialized = false;
+	}
 }
 

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -368,8 +368,10 @@ bool
 rdp_event_loop_add_fd(struct wl_event_loop *loop, int fd, uint32_t mask, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source)
 {
 	*event_source = wl_event_loop_add_fd(loop, fd, 0, func, data);
-	if (!*event_source)
+	if (!*event_source) {
+		weston_log("%s: wl_event_loop_add_fd failed.\n", __func__);
 		return false;
+	}
 
 	wl_event_source_fd_update(*event_source, mask);
 	return true;
@@ -445,7 +447,6 @@ rdp_initialize_dispatch_task_event_source(RdpPeerContext *peerCtx)
 	if (!rdp_event_loop_add_fd(
 		loop, peerCtx->loop_task_event_source_fd, WL_EVENT_READABLE,
 		rdp_dispatch_task, peerCtx, &peerCtx->loop_task_event_source)) {
-		rdp_debug_error(b, "%s: rdp_event_loop_add_fd() failed\n", __func__);
 		goto error_event_loop_add_fd;
 	}
 


### PR DESCRIPTION
This change is to make sure the multi-threading safe task dispatching from FreeRDP thread to Wayland display loop thread.