### PR TITLE
fix missing free for client string at shell destruction

### DIFF
--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -4078,6 +4078,7 @@ shell_destroy(struct wl_listener *listener, void *data)
 	if (shell->debug)
 		weston_log_scope_destroy(shell->debug);
 
+	free(shell->client);
 	free(shell);
 }
 


### PR DESCRIPTION
fix missing free for client string at shell destruction