### PR TITLE
report correct marker window's zorder

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -165,8 +165,11 @@ struct weston_rdprail_api {
 
 	/** Update window zorder
 	 */
-	void (*notify_window_zorder_change)(struct weston_compositor *compositor,
-		struct weston_surface *surface);
+	void (*notify_window_zorder_change)(struct weston_compositor *compositor);
+
+	/** Notify window proxy surface
+	 */
+	void (*notify_window_proxy_surface)(struct weston_surface *proxy_surface);
 };
 
 static inline const struct weston_rdprail_api *

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -139,6 +139,8 @@ struct rdp_backend {
 
 	int rdp_monitor_refresh_rate;
 
+	struct weston_surface *proxy_surface;
+
 #ifdef HAVE_FREERDP_RDPAPPLIST_H
 	/* import from libfreerdp-server2.so */
 	RdpAppListServerContext* (*rdpapplist_server_context_new)(HANDLE vcm);
@@ -269,7 +271,6 @@ struct rdp_peer_context {
 	struct wl_listener wake_listener;
 
 	bool is_window_zorder_dirty;
-	struct weston_surface *active_surface;
 
 	// Multiple monitor support (monitor topology)
 	pixman_region32_t regionClientHeads;


### PR DESCRIPTION
This fixes the problems when Linux window is activated by clicking Linux application's icon on Windows taskbar, It will bring up the Linux application foreground on Windows's desktop, but it also brought up all other Linux application's windows above all other Windows's window because marker window (which presents the highest Windows's window) is placed at bottom in zorder, this PR fixes this by inserting marker window at where proxy_window is, (the proxy_window is the hidden window on Linux desktop representing the highest Windows's window).