### PR TITLE
clean up 'todo' coordinate conversion to client space for local window move.

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -540,20 +540,6 @@ to_weston_coordinate(RdpPeerContext *peerContext, int32_t *x, int32_t *y, uint32
 	return NULL;
 }
 
-/* TO BE REMOVED */
-static inline int32_t
-to_client_x(RdpPeerContext *peer, int32_t x)
-{
-	return x + peer->regionClientHeads.extents.x1;
-}
-
-/* TO BE REMOVED */
-static inline int32_t
-to_client_y(RdpPeerContext *peer, int32_t y)
-{
-	return y + peer->regionClientHeads.extents.y1;
-}
-
 static inline void
 to_client_scale_only(RdpPeerContext *peer, struct weston_output *output, float scale, int *x, int *y)
 {

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -2744,8 +2744,14 @@ shell_backend_request_window_move(struct weston_surface *surface, int x, int y, 
 	}
 
 	assert(!shsurf->snapped.is_maximized_requested);
+
+	if (surface->width != width || surface->height != height) {
+		//TODO: support window resize (width x height)
+		shell_rdp_debug(shsurf->shell, "%s: surface:%p is resized (%dx%d) -> (%d,%d)\n",
+			__func__, surface, surface->width, surface->height, width, height);
+	}
+
 	weston_view_set_position(view, x, y);
-	//TODO: support window resize (width x height)
 }
 
 static void
@@ -2810,11 +2816,10 @@ shell_backend_request_window_snap(struct weston_surface *surface, int x, int y, 
 			height = min_size.height;
 		else if (max_size.width > 0 && width > max_size.width)
 			width = max_size.width;
-		
-		weston_desktop_surface_set_size(desktop_surface, width, height);
 
-		x -= surface->input.extents.x1;
-		y -= surface->input.extents.y1;
+		shell_rdp_debug(shsurf->shell, "%s: surface:%p is resized (%dx%d) -> (%d,%d)\n",
+			__func__, surface, surface->width, surface->height, width, height);
+		weston_desktop_surface_set_size(desktop_surface, width, height);
 	}
 
 	weston_view_set_position(view, x, y);


### PR DESCRIPTION
this supports HI-DPI coordinate conversion to client space and window geometry adjustment when window shadow is not remoted to client for local window move. Also remove the offsetting by input extent at shell for snap.