### PR TITLE
rdp: Move audio processing to front-end

### DIFF
--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -1,6 +1,8 @@
 srcs_weston = [
 	git_version_h,
 	'main.c',
+	'rdpaudio.c',
+	'rdpaudioin.c',
 	'testsuite-util.c',
 	'text-backend.c',
 	'weston-screenshooter.c',
@@ -18,6 +20,8 @@ deps_weston = [
 	dep_libevdev,
 	dep_libdl,
 	dep_threads,
+	dep_frdp,
+	dep_frdp_server,
 ]
 
 if get_option('xwayland')

--- a/compositor/rdpaudio.h
+++ b/compositor/rdpaudio.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright © 2022 Microsoft
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef RDP_AUDIO_H
+#define RDP_AUDIO_H
+
+#include <libweston/libweston.h>
+#include <libweston/weston-log.h>
+#include <freerdp/server/rdpsnd.h>
+#include <freerdp/server/audin.h>
+
+#define rdp_audio_debug(p, ...) \
+	weston_log_scope_printf((p)->debug, __VA_ARGS__)
+
+typedef struct _rdp_audio_block_info {
+	UINT64 submissionTime;
+	UINT64 ackReceivedTime;
+	UINT64 ackPlayedTime;
+} rdp_audio_block_info;
+
+struct audio_out_private {
+	RdpsndServerContext* rdpsnd_server_context;
+	struct weston_log_scope *debug;
+	BOOL audioExitSignal;
+	int pulseAudioSinkListenerFd;
+	int pulseAudioSinkFd;
+	pthread_t pulseAudioSinkThread;
+	int bytesPerFrame;
+	UINT audioBufferSize;
+	BYTE* audioBuffer;
+	BYTE lastBlockSent;
+	UINT64 lastNetworkLatency;
+	UINT64 accumulatedNetworkLatency;
+	UINT accumulatedNetworkLatencyCount;
+	UINT64 lastRenderedLatency;
+	UINT64 accumulatedRenderedLatency;
+	UINT accumulatedRenderedLatencyCount;
+	rdp_audio_block_info blockInfo[256];
+	int nextValidBlock;
+	UINT PAVersion;
+	int audioSem;
+};
+
+struct audio_in_private {
+	audin_server_context* audin_server_context;
+	struct weston_log_scope *debug;
+	BOOL audioInExitSignal;
+	int pulseAudioSourceListenerFd;
+	int pulseAudioSourceFd;
+	int closeAudioSourceFd;
+	pthread_t pulseAudioSourceThread;
+	BOOL isAudioInStreamOpened;
+};
+
+void *
+rdp_audio_out_init(struct weston_compositor *c, HANDLE vcm);
+
+void
+rdp_audio_out_destroy(void *audio_out_private);
+
+void *
+rdp_audio_in_init(struct weston_compositor *c, HANDLE vcm);
+
+void
+rdp_audio_in_destroy(void *audio_in_private);
+
+
+#endif

--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -244,6 +244,11 @@ struct weston_surface_rail_state {
 
 #define WESTON_RDP_BACKEND_CONFIG_VERSION 3
 
+typedef void *(*rdp_audio_in_setup)(struct weston_compositor *c, void *vcm);
+typedef void (*rdp_audio_in_teardown)(void *audio_private);
+typedef void *(*rdp_audio_out_setup)(struct weston_compositor *c, void *vcm);
+typedef void (*rdp_audio_out_teardown)(void *audio_private);
+
 struct weston_rdp_backend_config {
 	struct weston_backend_config base;
 	char *bind_address;
@@ -255,8 +260,10 @@ struct weston_rdp_backend_config {
 	int no_clients_resize;
 	int force_no_compression;
 	bool redirect_clipboard;
-	bool redirect_audio_playback;
-	bool redirect_audio_capture;
+	rdp_audio_in_setup audio_in_setup;
+	rdp_audio_in_teardown audio_in_teardown;
+	rdp_audio_out_setup audio_out_setup;
+	rdp_audio_out_teardown audio_out_teardown;
 	int rdp_monitor_refresh_rate;
 	struct {
 		bool use_rdpapplist;

--- a/libweston/backend-rdp/meson.build
+++ b/libweston/backend-rdp/meson.build
@@ -64,8 +64,6 @@ endif
 srcs_rdp = [
         'hash.c',
         'rdp.c',
-        'rdpaudio.c',
-        'rdpaudioin.c',
         'rdpdisp.c',
         'rdpclip.c',
         'rdprail.c',

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -110,8 +110,10 @@ struct rdp_backend {
 	int no_clients_resize;
 	int force_no_compression;
 	bool redirect_clipboard;
-	bool redirect_audio_playback;
-	bool redirect_audio_capture;
+	rdp_audio_in_setup audio_in_setup;
+	rdp_audio_in_teardown audio_in_teardown;
+	rdp_audio_out_setup audio_out_setup;
+	rdp_audio_out_teardown audio_out_teardown;
 
 	const struct weston_rdprail_shell_api *rdprail_shell_api;
 	void *rdprail_shell_context;
@@ -277,35 +279,8 @@ struct rdp_peer_context {
 	pixman_region32_t regionClientHeads;
 	pixman_region32_t regionWestonHeads;
 
-	// Audio support
-	RdpsndServerContext* rdpsnd_server_context;
-	BOOL audioExitSignal;
-	int pulseAudioSinkListenerFd;
-	int pulseAudioSinkFd;
-	pthread_t pulseAudioSinkThread;
-	int bytesPerFrame;
-	UINT audioBufferSize;
-	BYTE* audioBuffer;
-	BYTE lastBlockSent;
-	UINT64 lastNetworkLatency;
-	UINT64 accumulatedNetworkLatency;
-	UINT accumulatedNetworkLatencyCount;
-	UINT64 lastRenderedLatency;
-	UINT64 accumulatedRenderedLatency;
-	UINT accumulatedRenderedLatencyCount;
-	rdp_audio_block_info blockInfo[256];
-	int nextValidBlock;
-	UINT PAVersion;
-
-	// AudioIn support
-	audin_server_context* audin_server_context;
-	BOOL audioInExitSignal;
-	int pulseAudioSourceListenerFd;
-	int pulseAudioSourceFd;
-	int closeAudioSourceFd;
-	int audioInSem;
-	pthread_t pulseAudioSourceThread;
-	BOOL isAudioInStreamOpened;
+	void *audio_in_private;
+	void *audio_out_private;
 
 	// Clipboard support
 	CliprdrServerContext* clipboard_server_context;
@@ -437,14 +412,6 @@ void rdp_rail_end_window_move(struct weston_surface* surface);
 // rdpdisp.c
 UINT disp_client_monitor_layout_change(DispServerContext* context, const DISPLAY_CONTROL_MONITOR_LAYOUT_PDU* displayControl);
 BOOL xf_peer_adjust_monitor_layout(freerdp_peer* client);
-
-// rdpaudio.c
-int rdp_audio_init(RdpPeerContext *peerCtx);
-void rdp_audio_destroy(RdpPeerContext *peerCtx);
-
-// rdpaudioin.c
-int rdp_audioin_init(RdpPeerContext *peerCtx);
-void rdp_audioin_destroy(RdpPeerContext *peerCtx);
 
 // rdpclip.c
 int rdp_clipboard_init(freerdp_peer* client);


### PR DESCRIPTION
Move the bulk of the audio related code into the compositor front end, and
instead put callbacks to setup functions into the rdp backend config
structure.

There are some changes to logging because we no longer have access to the
backend's logging scopes. Instead we create rdp-audio and rdp-audio-in
scopes.

Signed-off-by: Derek Foreman <derek.foreman@collabora.com>