### PR TITLE
xwm: Generate more synthetic ConfigureNotify events

### DIFF
--- a/desktop-shell/shell.c
+++ b/desktop-shell/shell.c
@@ -2965,6 +2965,17 @@ desktop_surface_set_xwayland_position(struct weston_desktop_surface *surface,
 	shsurf->xwayland.is_set = true;
 }
 
+static void
+desktop_surface_get_position(struct weston_desktop_surface *surface,
+			     int32_t *x, int32_t *y,
+			     void *shell_)
+{
+	struct shell_surface *shsurf = weston_desktop_surface_get_user_data(surface);
+
+	*x = shsurf->view->geometry.x;
+	*y = shsurf->view->geometry.y;
+}
+
 static const struct weston_desktop_api shell_desktop_api = {
 	.struct_size = sizeof(struct weston_desktop_api),
 	.surface_added = desktop_surface_added,
@@ -2979,6 +2990,7 @@ static const struct weston_desktop_api shell_desktop_api = {
 	.ping_timeout = desktop_surface_ping_timeout,
 	.pong = desktop_surface_pong,
 	.set_xwayland_position = desktop_surface_set_xwayland_position,
+	.get_position = desktop_surface_get_position,
 };
 
 /* ************************ *

--- a/include/libweston-desktop/libweston-desktop.h
+++ b/include/libweston-desktop/libweston-desktop.h
@@ -117,6 +117,9 @@ struct weston_desktop_api {
 	 */
 	void (*set_xwayland_position)(struct weston_desktop_surface *surface,
 				      int32_t x, int32_t y, void *user_data);
+	void (*get_position)(struct weston_desktop_surface *surface,
+			     int32_t *x, int32_t *y,
+			     void *user_data);
 	/*
 	 * In contrast to above set_xwayland_position(), move_xwayland_position()
 	 * to be used to move window after mapped.

--- a/kiosk-shell/kiosk-shell.c
+++ b/kiosk-shell/kiosk-shell.c
@@ -812,6 +812,17 @@ desktop_surface_set_xwayland_position(struct weston_desktop_surface *desktop_sur
 	shsurf->xwayland.is_set = true;
 }
 
+static void
+desktop_surface_get_position(struct weston_desktop_surface *desktop_surface,
+			     int32_t *x, int32_t *y, void *shell)
+{
+	struct kiosk_shell_surface *shsurf =
+		weston_desktop_surface_get_user_data(desktop_surface);
+
+	*x = shsurf->view->geometry.x;
+	*y = shsurf->view->geometry.y;
+}
+
 static const struct weston_desktop_api kiosk_shell_desktop_api = {
 	.struct_size = sizeof(struct weston_desktop_api),
 	.surface_added = desktop_surface_added,
@@ -826,6 +837,7 @@ static const struct weston_desktop_api kiosk_shell_desktop_api = {
 	.ping_timeout = desktop_surface_ping_timeout,
 	.pong = desktop_surface_pong,
 	.set_xwayland_position = desktop_surface_set_xwayland_position,
+	.get_position = desktop_surface_get_position,
 };
 
 /*

--- a/libweston-desktop/internal.h
+++ b/libweston-desktop/internal.h
@@ -92,6 +92,11 @@ weston_desktop_api_set_xwayland_position(struct weston_desktop *desktop,
 					 int32_t x, int32_t y);
 
 void
+weston_desktop_api_get_position(struct weston_desktop *desktop,
+				struct weston_desktop_surface *surface,
+				int32_t *x, int32_t *y);
+
+void
 weston_desktop_api_move_xwayland_position(struct weston_desktop *desktop,
 					  struct weston_desktop_surface *surface,
 					  int32_t x, int32_t y);

--- a/libweston-desktop/libweston-desktop.c
+++ b/libweston-desktop/libweston-desktop.c
@@ -264,6 +264,17 @@ weston_desktop_api_set_xwayland_position(struct weston_desktop *desktop,
 }
 
 void
+weston_desktop_api_get_position(struct weston_desktop *desktop,
+				struct weston_desktop_surface *surface,
+				int32_t *x, int32_t *y)
+{
+	if (!desktop->api.get_position)
+		return;
+
+	desktop->api.get_position(surface, x, y, desktop->user_data);
+}
+
+void
 weston_desktop_api_move_xwayland_position(struct weston_desktop *desktop,
 					  struct weston_desktop_surface *surface,
 					  int32_t x, int32_t y)

--- a/libweston-desktop/xwayland.c
+++ b/libweston-desktop/xwayland.c
@@ -428,6 +428,18 @@ set_pid(struct weston_desktop_xwayland_surface *surface, pid_t pid)
 	weston_desktop_surface_set_pid(surface->surface, pid);
 }
 
+static void
+get_position(struct weston_desktop_xwayland_surface *surface,
+	     int32_t *x, int32_t *y)
+{
+	if (!surface->surface) {
+		*x = 0;
+		*y = 0;
+		return;
+	}
+	weston_desktop_api_get_position(surface->desktop, surface->surface, x, y);
+}
+
 static const struct weston_desktop_xwayland_interface weston_desktop_xwayland_interface = {
 	.create_surface = create_surface,
 	.set_toplevel = set_toplevel,
@@ -444,6 +456,7 @@ static const struct weston_desktop_xwayland_interface weston_desktop_xwayland_in
 	.set_maximized = set_maximized,
 	.set_minimized = set_minimized,
 	.set_pid = set_pid,
+	.get_position = get_position,
 	.set_window_icon = set_window_icon,
 };
 

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -2960,6 +2960,17 @@ desktop_surface_set_xwayland_position(struct weston_desktop_surface *surface,
 }
 
 static void
+desktop_surface_get_position(struct weston_desktop_surface *surface,
+			     int32_t *x, int32_t *y,
+			     void *shell_)
+{
+	struct shell_surface *shsurf = weston_desktop_surface_get_user_data(surface);
+
+	*x = shsurf->view->geometry.x;
+	*y = shsurf->view->geometry.y;
+}
+
+static void
 desktop_surface_move_xwayland_position(struct weston_desktop_surface *desktop_surface,
 				       int32_t x, int32_t y, void *shell_)
 {
@@ -3008,6 +3019,7 @@ static const struct weston_desktop_api shell_desktop_api = {
 	.ping_timeout = desktop_surface_ping_timeout,
 	.pong = desktop_surface_pong,
 	.set_xwayland_position = desktop_surface_set_xwayland_position,
+	.get_position = desktop_surface_get_position,
 	.move_xwayland_position = desktop_surface_move_xwayland_position,
 	.set_window_icon = desktop_surface_set_window_icon,
 };

--- a/xwayland/xwayland-internal-interface.h
+++ b/xwayland/xwayland-internal-interface.h
@@ -62,8 +62,10 @@ struct weston_desktop_xwayland_interface {
 	void (*set_maximized)(struct weston_desktop_xwayland_surface *shsurf);
 	void (*set_minimized)(struct weston_desktop_xwayland_surface *shsurf);
 	void (*set_pid)(struct weston_desktop_xwayland_surface *shsurf, pid_t pid);
+	void (*get_position)(struct weston_desktop_xwayland_surface *surface,
+			     int32_t *x, int32_t *y);
 	void (*set_window_icon)(struct weston_desktop_xwayland_surface *surface,
-				int32_t width, int32_t height, int32_t bpp, void *bits);
+			        int32_t width, int32_t height, int32_t bpp, void *bits);
 };
 
 #endif


### PR DESCRIPTION
This is back porting https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/920 with minor tweak to accommodate https://github.com/microsoft/weston-mirror/pull/17 and https://github.com/microsoft/weston-mirror/pull/19. This fixes various menu window position issues and https://github.com/microsoft/wslg/issues/307.