### PR TITLE
xwm: fix window geometry for non-decorated window

### DIFF
--- a/xwayland/window-manager.c
+++ b/xwayland/window-manager.c
@@ -1503,6 +1503,7 @@ weston_wm_window_set_pending_state(struct weston_wm_window *window)
 	int32_t input_x, input_y, input_w, input_h;
 	const struct weston_desktop_xwayland_interface *xwayland_interface =
 		window->wm->server->compositor->xwayland_interface;
+	struct theme *t = window->wm->theme;
 
 	if (!window->surface)
 		return;
@@ -1523,14 +1524,19 @@ weston_wm_window_set_pending_state(struct weston_wm_window *window)
 					  window->height + 2);
 	}
 
-	if (window->frame && !window->fullscreen) {
-		frame_input_rect(window->frame, &input_x, &input_y,
-				 &input_w, &input_h);
-	} else {
+	if (window->fullscreen) {
 		input_x = x;
 		input_y = y;
 		input_w = width;
 		input_h = height;
+	} else if (window->decorate && window->frame) {
+		frame_input_rect(window->frame, &input_x, &input_y,
+				 &input_w, &input_h);
+	} else {
+		input_x = t->margin;
+		input_y = t->margin;
+		input_w = window->width;
+		input_h = window->height;
 	}
 
 	wm_printf(window->wm, "XWM: win %d geometry: %d,%d %dx%d\n",

--- a/xwayland/window-manager.c
+++ b/xwayland/window-manager.c
@@ -1523,7 +1523,7 @@ weston_wm_window_set_pending_state(struct weston_wm_window *window)
 					  window->height + 2);
 	}
 
-	if (window->decorate && !window->fullscreen) {
+	if (window->frame && !window->fullscreen) {
 		frame_input_rect(window->frame, &input_x, &input_y,
 				 &input_w, &input_h);
 	} else {


### PR DESCRIPTION
fix window geometry for non-decorated window, this fixes Google chrome/Microsoft Edge still have window shadow remoted to Windows side even with that feature disabled (WESTON_RDP_WINDOW_SHADOW_REMOTING=0). It takes similar patten as weston_wm_window_get_frame_size(), but when window is not fullscreen nor decorated, use bare window size as width/height, and margin from theme as offset x/y.