### PR TITLE
rdp-backend: add window resize margin when window shadow remoting is disabled

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -233,6 +233,11 @@ struct weston_surface_rail_state {
 	void *get_label;
 	int taskbarButton;
 
+	uint32_t window_margin_top;
+	uint32_t window_margin_left;
+	uint32_t window_margin_right;
+	uint32_t window_margin_bottom;
+
 	/* gfxredir shared memory */
 	uint32_t pool_id;
 	uint32_t buffer_id;

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -538,7 +538,7 @@ to_client_coordinate(RdpPeerContext *peerContext, struct weston_output *output, 
 	}
 }
 
-#define RDP_RAIL_WINDOW_RESIZE_MARGIN 4
+#define RDP_RAIL_WINDOW_RESIZE_MARGIN 8
 
 static inline bool
 is_window_shadow_remoting_disabled(RdpPeerContext *peerCtx)

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -538,4 +538,20 @@ to_client_coordinate(RdpPeerContext *peerContext, struct weston_output *output, 
 	}
 }
 
+#define RDP_RAIL_WINDOW_RESIZE_MARGIN 4
+
+static inline bool
+is_window_shadow_remoting_disabled(RdpPeerContext *peerCtx)
+{
+	struct rdp_backend *b = peerCtx->rdpBackend;
+
+	/* When shadow is not remoted, window geometry must be able to queried from shell to clip
+	   shadow area, and resize margin must be supported by client. When remoting window shadow,
+	   the shadow area is used as resize margin, but without it, window can't be resizable,
+	   thus window margin must be added by client side. */
+	return (!b->enable_window_shadow_remoting &&
+			b->rdprail_shell_api && b->rdprail_shell_api->get_window_geometry &&
+			(peerCtx->clientStatusFlags & TS_RAIL_CLIENTSTATUS_WINDOW_RESIZE_MARGIN_SUPPORTED));
+}
+
 #endif

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -346,9 +346,8 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 			to_weston_coordinate(peerCtx,
 				&snapArrangeRect.x, &snapArrangeRect.y,
 				&snapArrangeRect.width, &snapArrangeRect.height);
-			if (!b->enable_window_shadow_remoting &&
-				b->rdprail_shell_api &&
-				b->rdprail_shell_api->get_window_geometry) {
+			if (is_window_shadow_remoting_disabled(peerCtx)) {
+				/* offset window shadow area */
 				/* window_geometry here is last commited geometry */
 				b->rdprail_shell_api->get_window_geometry(surface, &windowGeometry);
 				snapArrangeRect.x -= windowGeometry.x;
@@ -411,9 +410,8 @@ rail_client_WindowMove_callback(bool freeOnly, void *arg)
 			to_weston_coordinate(peerCtx,
 				&windowMoveRect.x, &windowMoveRect.y,
 				&windowMoveRect.width, &windowMoveRect.height);
-			if (!b->enable_window_shadow_remoting &&
-				b->rdprail_shell_api &&
-				b->rdprail_shell_api->get_window_geometry) {
+			if (is_window_shadow_remoting_disabled(peerCtx)) {
+				/* offset window shadow area */
 				/* window_geometry here is last commited geometry */
 				b->rdprail_shell_api->get_window_geometry(surface, &windowGeometry);
 				windowMoveRect.x -= windowGeometry.x;
@@ -1394,9 +1392,8 @@ rdp_rail_create_window(struct wl_listener *listener, void *data)
 		rdp_debug_verbose(b, "%s: surface has no view (windowId:0x%x)\n", __func__, rail_state->window_id);
 	}
 
-	if (!b->enable_window_shadow_remoting &&
-		b->rdprail_shell_api &&
-		b->rdprail_shell_api->get_window_geometry) {
+	if (is_window_shadow_remoting_disabled(peerCtx)) {
+		/* drop window shadow area */
 		b->rdprail_shell_api->get_window_geometry(surface, &windowGeometry);
 		clientPos.x += windowGeometry.x;
 		clientPos.y += windowGeometry.y;
@@ -1470,6 +1467,16 @@ rdp_rail_create_window(struct wl_listener *listener, void *data)
 	window_order_info.fieldFlags |= WINDOW_ORDER_FIELD_VISIBILITY;
 	window_state_order.numVisibilityRects = 1;
 	window_state_order.visibilityRects = &window_vis;
+
+	if (is_window_shadow_remoting_disabled(peerCtx)) {
+		/* add resize margin area */
+		window_order_info.fieldFlags |=
+			WINDOW_ORDER_FIELD_RESIZE_MARGIN_X | WINDOW_ORDER_FIELD_RESIZE_MARGIN_Y;
+		window_state_order.resizeMarginLeft = RDP_RAIL_WINDOW_RESIZE_MARGIN;
+		window_state_order.resizeMarginRight = RDP_RAIL_WINDOW_RESIZE_MARGIN;
+		window_state_order.resizeMarginTop = RDP_RAIL_WINDOW_RESIZE_MARGIN;
+		window_state_order.resizeMarginBottom = RDP_RAIL_WINDOW_RESIZE_MARGIN;
+	}
 
 	/*window_state_order.titleInfo = NULL; */
 	/*window_state_order.OverlayDescription = 0;*/
@@ -1837,9 +1844,8 @@ rdp_rail_update_window(struct weston_surface *surface, struct update_window_iter
 		rdp_debug_verbose(b, "%s: surface has no view (windowId:0x%x)\n", __func__, rail_state->window_id);
 	}
 
-	if (!b->enable_window_shadow_remoting &&
-		b->rdprail_shell_api &&
-		b->rdprail_shell_api->get_window_geometry) {
+	if (is_window_shadow_remoting_disabled(peerCtx)) {
+		/* drop window shadow area */
 		b->rdprail_shell_api->get_window_geometry(surface, &windowGeometry);
 		newClientPos.x += windowGeometry.x;
 		newClientPos.y += windowGeometry.y;
@@ -2254,7 +2260,7 @@ rdp_rail_update_window(struct weston_surface *surface, struct update_window_iter
 			}
 			/* damageBox represents damaged area in contentBuffer */
 			/* if it's not remoting window shadow, exclude the area from damageBox */
-			if (!b->enable_window_shadow_remoting) {
+			if (is_window_shadow_remoting_disabled(peerCtx)) {
 				if (damageBox.x1 < contentBufferWindowGeometry.x)
 					damageBox.x1 = contentBufferWindowGeometry.x;
 				if (damageBox.x2 > contentBufferWindowGeometry.x + contentBufferWindowGeometry.width)
@@ -3133,9 +3139,8 @@ rdp_rail_start_window_move(
 		rdp_debug_verbose(b, "%s: surface has no view (windowId:0x%x)\n", __func__, rail_state->window_id);
 	}
 
-	if (!b->enable_window_shadow_remoting &&
-		b->rdprail_shell_api &&
-		b->rdprail_shell_api->get_window_geometry) {
+	if (is_window_shadow_remoting_disabled(peerCtx)) {
+		/* offset window shadow area */
 		b->rdprail_shell_api->get_window_geometry(surface, &windowGeometry);
 		posX += windowGeometry.x;
 		posY += windowGeometry.y;
@@ -3236,9 +3241,8 @@ rdp_rail_end_window_move(struct weston_surface* surface)
 		rdp_debug_verbose(b, "%s: surface has no view (windowId:0x%x)\n", __func__, rail_state->window_id);
 	}
 
-	if (!b->enable_window_shadow_remoting &&
-		b->rdprail_shell_api &&
-		b->rdprail_shell_api->get_window_geometry) {
+	if (is_window_shadow_remoting_disabled(peerCtx)) {
+		/* offset window shadow area */
 		b->rdprail_shell_api->get_window_geometry(surface, &windowGeometry);
 		posX += windowGeometry.x;
 		posY += windowGeometry.y;

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -4456,9 +4456,13 @@ shell_backend_get_window_geometry(struct weston_surface *surface, struct weston_
 			geometry->x = 0;
 		if (geometry->y < 0)
 			geometry->y = 0;
-		if (geometry->width > (geometry->x + surface->width))
+		if (geometry->width == 0)
+			geometry->width = surface->width;
+		else if (geometry->width > (geometry->x + surface->width))
 			geometry->width = (geometry->x + surface->width);
-		if (geometry->height > (geometry->y + surface->height))
+		if (geometry->height == 0)
+			geometry->height = surface->height;
+		else if (geometry->height > (geometry->y + surface->height))
 			geometry->height = (geometry->y + surface->height);
 	} else {
 		geometry->x = 0;


### PR DESCRIPTION
add window resize margin when window shadow remoting is disabled. This to address Wayland native app (such as gedit) can't be resizable when window shadow is not remoted. When window shadow is remoted, the shadow area can be used for resize grab hit test area, but without it, mouse can't grab resize, thus when shadow is not remoted, add window resize margin by RDP.