### PR TITLE
rdp: resize margin adjustment for MoveWindow/SnapArrange PDU

### DIFF
--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -346,6 +346,14 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 			snapArrangeRect.y = snap->top;
 			snapArrangeRect.width = snap->right - snap->left;
 			snapArrangeRect.height = snap->bottom - snap->top;
+			/* SnapArrang PDU include window resize margin */
+			/* [MS-RDPERP] - v20200304 - 3.2.5.1.6 Processing Window Information Orders
+			    However, the Client Window Move PDU (section 2.2.2.7.4) and Client Window Snap PDU
+			    (section 2.2.2.7.5) do include resize margins in the window boundaries. */
+			snapArrangeRect.x += rail_state->window_margin_left;
+			snapArrangeRect.y += rail_state->window_margin_top;
+			snapArrangeRect.width -= (rail_state->window_margin_left + rail_state->window_margin_right);
+			snapArrangeRect.height -= (rail_state->window_margin_top + rail_state->window_margin_bottom);
 			to_weston_coordinate(peerCtx,
 				&snapArrangeRect.x, &snapArrangeRect.y,
 				&snapArrangeRect.width, &snapArrangeRect.height);
@@ -363,10 +371,9 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 				snapArrangeRect.y,
 				snapArrangeRect.width,
 				snapArrangeRect.height);
+			rail_state->forceUpdateWindowState = true;
+			rdp_rail_schedule_update_window(NULL, (void*)surface);
 		}
-
-		rail_state->forceUpdateWindowState = true;
-		rdp_rail_schedule_update_window(NULL, (void*)surface);
 	}
 
 	free(data);
@@ -388,6 +395,7 @@ rail_client_WindowMove_callback(bool freeOnly, void *arg)
 	RdpPeerContext *peerCtx = (RdpPeerContext *)client->context;
 	struct rdp_backend *b = peerCtx->rdpBackend;
 	struct weston_surface *surface;
+	struct weston_surface_rail_state *rail_state;
 	pixman_rectangle32_t windowMoveRect;
 	struct weston_geometry windowGeometry;
 
@@ -404,12 +412,21 @@ rail_client_WindowMove_callback(bool freeOnly, void *arg)
 	if (!freeOnly)
 		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, windowMove->windowId);
 	if (surface) {
+		rail_state = (struct weston_surface_rail_state *)surface->backend_state;
 		if (b->rdprail_shell_api &&
 			b->rdprail_shell_api->request_window_move) {
 			windowMoveRect.x = windowMove->left;
 			windowMoveRect.y = windowMove->top;
 			windowMoveRect.width = windowMove->right - windowMove->left;
 			windowMoveRect.height = windowMove->bottom - windowMove->top;
+			/* WindowMove PDU include window resize margin */
+			/* [MS-RDPERP] - v20200304 - 3.2.5.1.6 Processing Window Information Orders
+			    However, the Client Window Move PDU (section 2.2.2.7.4) and Client Window Snap PDU
+			    (section 2.2.2.7.5) do include resize margins in the window boundaries. */
+			windowMoveRect.x += rail_state->window_margin_left;
+			windowMoveRect.y += rail_state->window_margin_top;
+			windowMoveRect.width -= (rail_state->window_margin_left + rail_state->window_margin_right);
+			windowMoveRect.height -= (rail_state->window_margin_top + rail_state->window_margin_bottom);
 			to_weston_coordinate(peerCtx,
 				&windowMoveRect.x, &windowMoveRect.y,
 				&windowMoveRect.width, &windowMoveRect.height);
@@ -427,6 +444,8 @@ rail_client_WindowMove_callback(bool freeOnly, void *arg)
 				windowMoveRect.y,
 				windowMoveRect.width,
 				windowMoveRect.height);
+			rail_state->forceUpdateWindowState = true;
+			rdp_rail_schedule_update_window(NULL, (void*)surface);
 		}
 	}
 

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -346,7 +346,7 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 			snapArrangeRect.y = snap->top;
 			snapArrangeRect.width = snap->right - snap->left;
 			snapArrangeRect.height = snap->bottom - snap->top;
-			/* SnapArrang PDU include window resize margin */
+			/* SnapArrange PDU include window resize margin */
 			/* [MS-RDPERP] - v20200304 - 3.2.5.1.6 Processing Window Information Orders
 			    However, the Client Window Move PDU (section 2.2.2.7.4) and Client Window Snap PDU
 			    (section 2.2.2.7.5) do include resize margins in the window boundaries. */

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -339,7 +339,7 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 	if (!freeOnly)
 		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, snap->windowId);
 	if (surface) {
-		rail_state = (struct weston_surface_rail_state *)surface->backend_state;
+		rail_state = surface->backend_state;
 		if (b->rdprail_shell_api &&
 			b->rdprail_shell_api->request_window_snap) {
 			snapArrangeRect.x = snap->left;
@@ -352,8 +352,10 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 			    (section 2.2.2.7.5) do include resize margins in the window boundaries. */
 			snapArrangeRect.x += rail_state->window_margin_left;
 			snapArrangeRect.y += rail_state->window_margin_top;
-			snapArrangeRect.width -= (rail_state->window_margin_left + rail_state->window_margin_right);
-			snapArrangeRect.height -= (rail_state->window_margin_top + rail_state->window_margin_bottom);
+			snapArrangeRect.width -= rail_state->window_margin_left +
+						 rail_state->window_margin_right;
+			snapArrangeRect.height -= rail_state->window_margin_top +
+						  rail_state->window_margin_bottom;
 			to_weston_coordinate(peerCtx,
 				&snapArrangeRect.x, &snapArrangeRect.y,
 				&snapArrangeRect.width, &snapArrangeRect.height);
@@ -372,7 +374,7 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 				snapArrangeRect.width,
 				snapArrangeRect.height);
 			rail_state->forceUpdateWindowState = true;
-			rdp_rail_schedule_update_window(NULL, (void*)surface);
+			rdp_rail_schedule_update_window(NULL, surface);
 		}
 	}
 
@@ -412,7 +414,7 @@ rail_client_WindowMove_callback(bool freeOnly, void *arg)
 	if (!freeOnly)
 		surface = (struct weston_surface *)rdp_id_manager_lookup(&peerCtx->windowId, windowMove->windowId);
 	if (surface) {
-		rail_state = (struct weston_surface_rail_state *)surface->backend_state;
+		rail_state = surface->backend_state;
 		if (b->rdprail_shell_api &&
 			b->rdprail_shell_api->request_window_move) {
 			windowMoveRect.x = windowMove->left;
@@ -425,8 +427,10 @@ rail_client_WindowMove_callback(bool freeOnly, void *arg)
 			    (section 2.2.2.7.5) do include resize margins in the window boundaries. */
 			windowMoveRect.x += rail_state->window_margin_left;
 			windowMoveRect.y += rail_state->window_margin_top;
-			windowMoveRect.width -= (rail_state->window_margin_left + rail_state->window_margin_right);
-			windowMoveRect.height -= (rail_state->window_margin_top + rail_state->window_margin_bottom);
+			windowMoveRect.width -= rail_state->window_margin_left +
+						rail_state->window_margin_right;
+			windowMoveRect.height -= rail_state->window_margin_top +
+						 rail_state->window_margin_bottom;
 			to_weston_coordinate(peerCtx,
 				&windowMoveRect.x, &windowMoveRect.y,
 				&windowMoveRect.width, &windowMoveRect.height);
@@ -445,7 +449,7 @@ rail_client_WindowMove_callback(bool freeOnly, void *arg)
 				windowMoveRect.width,
 				windowMoveRect.height);
 			rail_state->forceUpdateWindowState = true;
-			rdp_rail_schedule_update_window(NULL, (void*)surface);
+			rdp_rail_schedule_update_window(NULL, surface);
 		}
 	}
 


### PR DESCRIPTION
resize margin adjustment is required for MoveWindow/SnapArrange PDU as these two PDU contains resize margin, thus the area must be removed before calculating newly snapped/moved window size for weston.