### PR TITLE
compositor: load xwayland module last

### DIFF
--- a/compositor/main.c
+++ b/compositor/main.c
@@ -963,7 +963,7 @@ wet_get_bindir_path(const char *name)
 
 static int
 load_modules(struct weston_compositor *ec, const char *modules,
-	     int *argc, char *argv[], bool *xwayland)
+	     int *argc, char *argv[])
 {
 	const char *p, *end;
 	char buffer[256];
@@ -977,11 +977,11 @@ load_modules(struct weston_compositor *ec, const char *modules,
 		snprintf(buffer, sizeof buffer, "%.*s", (int) (end - p), p);
 
 		if (strstr(buffer, "xwayland.so")) {
-			weston_log("Old Xwayland module loading detected: "
+			weston_log("fatal: Old Xwayland module loading detected: "
 				   "Please use --xwayland command line option "
 				   "or set xwayland=true in the [core] section "
 				   "in weston.ini\n");
-			*xwayland = true;
+			return -1;
 		} else {
 			if (wet_load_module(ec, buffer, argc, argv) < 0)
 				return -1;
@@ -3532,13 +3532,10 @@ wet_main(int argc, char *argv[])
 	if (wet_load_shell(wet.compositor, shell, &argc, argv) < 0)
 		goto out;
 
-	weston_config_section_get_string(section, "modules", &modules, "");
-	if (load_modules(wet.compositor, modules, &argc, argv, &xwayland) < 0)
-		goto out;
-
-	if (load_modules(wet.compositor, option_modules, &argc, argv, &xwayland) < 0)
-		goto out;
-
+	/* Load xwayland before other modules - this way if we're using
+	 * the systemd-notify module it will notify after we're ready
+	 * to receive xwayland connections.
+	 */
 	if (!xwayland) {
 		weston_config_section_get_bool(section, "xwayland", &xwayland,
 					       false);
@@ -3547,6 +3544,13 @@ wet_main(int argc, char *argv[])
 		if (wet_load_xwayland(wet.compositor) < 0)
 			goto out;
 	}
+
+	weston_config_section_get_string(section, "modules", &modules, "");
+	if (load_modules(wet.compositor, modules, &argc, argv) < 0)
+		goto out;
+
+	if (load_modules(wet.compositor, option_modules, &argc, argv) < 0)
+		goto out;
 
 	section = weston_config_get_section(config, "keyboard", NULL, NULL);
 	weston_config_section_get_bool(section, "numlock-on", &numlock_on, false);


### PR DESCRIPTION
Load xwayland module last, this is backport from upstream, https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/955, as this is needed for https://github.com/microsoft/wslg/pull/786, to close small possibility of race condition.