### PR TITLE
xwayland: Fix some xwayland focus bugs

### DIFF
--- a/xwayland/xwayland.h
+++ b/xwayland/xwayland.h
@@ -162,6 +162,7 @@ struct weston_wm {
 		xcb_atom_t		 xdnd_action_copy;
 		xcb_atom_t		 wl_surface_id;
 		xcb_atom_t		 allow_commits;
+		xcb_atom_t		 weston_focus_ping;
 	} atom;
 };
 


### PR DESCRIPTION
This is backporting the upstream patch of https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/899. This is replacing the previous fix to address 'xterm' issue locally made at WSLg downstream.