### PR TITLE
rdp shell: locate icon for taskbar using window class name

### DIFF
--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -408,6 +408,15 @@ shell_surface_set_window_icon(struct weston_desktop_surface *desktop_surface,
 				shsurf->icon.is_default_icon_used = false;
 		}
 		if (!image) {
+			/* If this is X app, try window class name as id for icon */
+			if (api && api->is_xwayland_surface(surface))
+				id = api->get_class_name(surface);
+			if (id)
+				image = app_list_load_icon_file(shsurf->shell, id);
+			if (image)
+				shsurf->icon.is_default_icon_used = false;
+		}
+		if (!image) {
 			/* When caller doens't supply custom image, look for default images */
 			image = shsurf->shell->image_default_app_icon;
 			if (image) {

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -409,12 +409,13 @@ shell_surface_set_window_icon(struct weston_desktop_surface *desktop_surface,
 		}
 		if (!image) {
 			/* If this is X app, try window class name as id for icon */
-			if (api && api->is_xwayland_surface(surface))
+			if (api && api->is_xwayland_surface(surface)) {
 				id = api->get_class_name(surface);
-			if (id)
-				image = app_list_load_icon_file(shsurf->shell, id);
-			if (image)
-				shsurf->icon.is_default_icon_used = false;
+				if (id)
+					image = app_list_load_icon_file(shsurf->shell, id);
+				if (image)
+					shsurf->icon.is_default_icon_used = false;
+			}
 		}
 		if (!image) {
 			/* When caller doens't supply custom image, look for default images */


### PR DESCRIPTION
Locate icon for taskbar using window class name when app doesn't have icon image in _NET_WM_ICON. This address taskbar icon remains generic penguin with JupyterLab Desktop.