### PR TITLE
xwayland: fix maximized window decoration

### DIFF
--- a/xwayland/window-manager.c
+++ b/xwayland/window-manager.c
@@ -2509,10 +2509,8 @@ weston_wm_handle_button(struct weston_wm *wm, xcb_generic_event_t *event)
 		if (weston_wm_window_is_maximized(window)) {
 			window->saved_width = window->width;
 			window->saved_height = window->height;
-			frame_set_flag(window->frame, FRAME_FLAG_MAXIMIZED);
 			xwayland_interface->set_maximized(window->shsurf);
 		} else {
-			frame_unset_flag(window->frame, FRAME_FLAG_MAXIMIZED);
 			weston_wm_window_set_toplevel(window);
 		}
 		frame_status_clear(window->frame, FRAME_STATUS_MAXIMIZE);


### PR DESCRIPTION
This addresses the issue which the window decoration is not rendered properly when window is maximized. This happens when application's window was already in the size equal to the maximized window, then transit to maximized state.

This is revised attempt to address this issue, the previous pull request (https://github.com/microsoft/weston-mirror/pull/111) was closed and was not merged.

The removing 2 lines were added by downstream (WSLg) long time ago as part of early-stage experimentation, which should have been removed. These 2 lines never exist at upstream branch.