### PR TITLE
xwm: Check size hints in weston_wm_window_is_positioned()

### DIFF
--- a/xwayland/window-manager.c
+++ b/xwayland/window-manager.c
@@ -3337,6 +3337,9 @@ weston_wm_window_is_positioned(struct weston_wm_window *window)
 		weston_log("XWM warning: win %d did not see map request\n",
 			   window->id);
 
+	if (window->size_hints.flags & (USPosition | PPosition))
+		return true;
+
 	return window->map_request_x != 0 || window->map_request_y != 0;
 }
 


### PR DESCRIPTION
This is backporting upstream change at https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1012.