### PR TITLE
rdp shell: make wslpath optional for obtaining windows path

### DIFF
--- a/rdprail-shell/app-list.c
+++ b/rdprail-shell/app-list.c
@@ -755,7 +755,7 @@ translate_to_windows_path(struct desktop_shell *shell, char *image_name, size_t 
 
 	attach_app_list_namespace(shell);
 
-	if (is_file_exist("/usr/bin/wslpath")) {
+	if (shell->use_wslpath && is_file_exist("/usr/bin/wslpath")) {
 		pid_t pid;
 		int pipe[2] = {};
 		int imageNameLength, len;

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -777,6 +777,11 @@ shell_configuration(struct desktop_shell *shell)
 					 shell->image_default_app_icon,
 					 shell->image_default_app_overlay_icon);
 
+	shell->use_wslpath = read_rdpshell_config_bool(
+		"WESTON_RDPRAIL_SHELL_USE_WSLPATH", false);
+	shell_rdp_debug(shell, "RDPRAIL-shell: WESTON_RDPRAIL_SHELL_USE_WSLPATH:%d\n",
+		shell->use_wslpath);
+
 	shell->workspaces.num = 1;
 }
 

--- a/rdprail-shell/shell.h
+++ b/rdprail-shell/shell.h
@@ -149,6 +149,8 @@ struct desktop_shell {
 	const struct weston_rdprail_api *rdprail_api;
 	void *rdp_backend;
 
+	bool use_wslpath;
+
 	struct weston_log_scope *debug;
 	uint32_t debugLevel;
 };


### PR DESCRIPTION
Make wslpath usage optional when converting Linux path to Windows path. For RDP's perspective, this information is not critical to operate WSLg.