### PR TITLE
rdp shell: fix missing va_end() call

### DIFF
--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -296,6 +296,7 @@ shell_rdp_debug_print(struct weston_log_scope *scope, bool cont, char *fmt, ...)
 							timestr, oom);
 			}
 		}
+		va_end(ap);
 	}
 }
 


### PR DESCRIPTION
fix missing va_end() call.