### PR TITLE
rdp shell: workaround get_position crash

### DIFF
--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -3005,9 +3005,17 @@ desktop_surface_get_position(struct weston_desktop_surface *surface,
 			     void *shell_)
 {
 	struct shell_surface *shsurf = weston_desktop_surface_get_user_data(surface);
-
-	*x = shsurf->view->geometry.x;
-	*y = shsurf->view->geometry.y;
+	if (shsurf) {
+		*x = shsurf->view->geometry.x;
+		*y = shsurf->view->geometry.y;
+	} else {
+		/* Ideally libweston-desktop/xwayland.c must not call shell if
+		   the surface is not reported to shell (surface.state == XWAYLAND),
+		   but unfortunately this does happen, thus here workaround the crash
+		   by returning (0,0) in such case. */
+		*x = 0;
+		*y = 0;
+	}
 }
 
 static bool


### PR DESCRIPTION
This is to address the issue reported at https://github.com/microsoft/wslg/issues/802, and the core dump provided at https://github.com/microsoft/wslg/issues/825#issuecomment-1285485833. This happen because libweston-desktop calls get_position shell callback with the desktop surface which is not added to shell, thus shell doesn't have own user data, thus segmentation fault occurs. Ideally libweston-desktop should not call shell for such surface, but this makes workaround and returns (0,0) for such case. While this allow AOSP Emulator to launch and makes emulator itself operatable, but still control panel window (the vertical companion window at right side of emulator which offers power, camera buttons and other settings) does not work. it does not respond on any mouse operations, thus need further investigation.