### PR TITLE
xwm: Fix selection if no seat present at startup

### DIFF
--- a/xwayland/window-manager.c
+++ b/xwayland/window-manager.c
@@ -3039,6 +3039,8 @@ weston_wm_destroy(struct weston_wm *wm)
 	weston_wm_destroy_cursors(wm);
 	xcb_disconnect(wm->conn);
 	wl_event_source_remove(wm->source);
+	wl_list_remove(&wm->seat_create_listener.link);
+	wl_list_remove(&wm->seat_destroy_listener.link);
 	wl_list_remove(&wm->selection_listener.link);
 	wl_list_remove(&wm->activate_listener.link);
 	wl_list_remove(&wm->kill_listener.link);

--- a/xwayland/xwayland.h
+++ b/xwayland/xwayland.h
@@ -91,6 +91,7 @@ struct weston_wm {
 	int flush_property_on_delete;
 	struct wl_listener selection_listener;
 	struct wl_listener seat_create_listener;
+	struct wl_listener seat_destroy_listener;
 
 	xcb_window_t dnd_window;
 	xcb_window_t dnd_owner;


### PR DESCRIPTION
WSLg downstream branch previously had local fix to address the case wayland seat might be present at startup due RDP connection, now the fix is made at upstream, https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/985, and this backports the fix.