### PR TITLE
rdp-backend: fix weston crash at RDP client disconnect

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -313,7 +313,8 @@ rdp_output_repaint(struct weston_output *output_base, pixman_region32_t *damage,
 		b->rdp_peer->context->settings->HiDefRemoteApp) {
 		/* RAIL mode, repaint RAIL window */
 		rdp_rail_output_repaint(output_base, damage);
-	} else if (output_base->renderer_state) {
+	} else if (output->shadow_surface &&
+			output_base->renderer_state) {
 		/* Add above 'output_base->renderer_state' check since this turns NULL when RDP
 		   connection is disconnected and hit fault at pixman_renderer_output_set_buffer() */
 		pixman_renderer_output_set_buffer(output_base, output->shadow_surface);


### PR DESCRIPTION
This fix weston crash at RDP client disconnect in RAIL mode, at rdp_output_repaint, after RAIL connection is disconnected, it mistakenly assumes desktop connection and it tried to repaint desktop on the given output, but no shadow buffer is allocated, thus crash. This adds the check on shadow buffer presence to avoid crash, but ideally once RDP client is disconnected, it should no longer paint desktop, and I will explore this on later.

(gdb) bt                                                                                                                        
=0  0x00007f3ae4394084 in pixman_image_unref () from target:/lib/libpixman-1.so.0                                               
=1  0x00007f3ae45063f1 in pixman_renderer_output_set_buffer (output=0x56078c397f60, **buffer=0x0**)                                     at ../libweston/pixman-renderer.c:929                                                                                       
=2  0x00007f3ae0b3ca50 in rdp_output_repaint (output_base=0x56078c397f60, damage=0x7ffdd8bd0ae0, repaint_data=0x0)                  at ../libweston/backend-rdp/rdp.c:319                                                                                       
=3  0x00007f3ae44eb230 in weston_output_repaint (output=0x56078c397f60, repaint_data=0x0) at ../libweston/compositor.c:2784     
=4  0x00007f3ae44eb4db in weston_output_maybe_repaint (output=0x56078c397f60, now=0x7ffdd8bd0bd0, repaint_data=0x0)                 at ../libweston/compositor.c:2851                                                                                           
=5  0x00007f3ae44eb748 in output_repaint_timer_handler (data=0x56078c36e7b0) at ../libweston/compositor.c:2924                  
=6  0x00007f3ae44b12e2 in wl_timer_heap_dispatch (timers=0x56078c36e298) at ../src/event-loop.c:526                             
=7  wl_event_loop_dispatch (loop=0x56078c36e250, timeout=timeout@entry=-1) at ../src/event-loop.c:1020                          
=8  0x00007f3ae44aea25 in wl_display_run (display=0x56078c36e390) at ../src/wayland-server.c:1431                               
=9  0x00007f3ae473e0fe in wet_main (argc=1, argv=0x7ffdd8bd1448) at ../compositor/main.c:3612                                   
=10 0x000056078b31d159 in main (argc=8, argv=0x7ffdd8bd1448) at ../compositor/executable.c:33