### PR TITLE
Build: use Ubuntu 20.04 for build verification

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ trigger:
   - working
   
 pool:
-  vmImage: 'ubuntu-latest'
+  vmImage: 'ubuntu-20.04'
 
 variables:
   prefix: '/usr/local'


### PR DESCRIPTION
For build verification, use Ubuntu 20.04 explicitly, as of today, using the ubuntu-latest fall into Ubuntu-22.04 and it causes conflict between libunwind-14-dev and libunwind-dev. This is only used for build verification but actual release of WSLg, actual release package of WSLg is built on Mariner distro.

 libunwind-14-dev : Breaks: libunwind-dev but 1.3.2-2build2 is to be installed
 