### PR TITLE
rdp shell: allow alt+F4 to close app

### DIFF
--- a/rdprail-shell/shell.h
+++ b/rdprail-shell/shell.h
@@ -117,6 +117,7 @@ struct desktop_shell {
 	} input_panel;
 
 	bool allow_zap;
+	bool allow_alt_f4_to_close_app;
 	uint32_t binding_modifier;
 
 	struct weston_layer minimized_layer;


### PR DESCRIPTION
This address the request made by https://github.com/microsoft/wslg/issues/187, and this option is enabled by default, but can be disabled by .wsl**g**config when this key sequence is used by application.