### PR TITLE
rdp fontend/backend/shell: keep compositor sleep until window is created

### DIFF
--- a/compositor/main.c
+++ b/compositor/main.c
@@ -3607,7 +3607,8 @@ wet_main(int argc, char *argv[])
 	if (argc > 1)
 		goto out;
 
-	weston_compositor_wake(wet.compositor);
+	/* Until RDP connection is established, keep compositor sleep state */
+	weston_compositor_sleep(wet.compositor);
 
 	wl_display_run(display);
 


### PR DESCRIPTION
This PR keeps compositor in sleep state until 1) window is created for RAIL remoting, 2) RDP connection is established for Desktop remoting. This also take power reference at client side unless GUI application is actually launched for RAIL.