### PR TITLE
libweston-desktop: xwayland window is not visible upon commit until mouse is moved

### DIFF
--- a/libweston-desktop/xwayland.c
+++ b/libweston-desktop/xwayland.c
@@ -170,7 +170,8 @@ weston_desktop_xwayland_surface_committed(struct weston_desktop_surface *dsurfac
 	if (surface->added)
 		weston_desktop_api_committed(surface->desktop, surface->surface,
 					     sx, sy);
-	else
+
+	if (surface->state == XWAYLAND)
 		weston_view_update_transform(surface->view);
 }
 

--- a/libweston-desktop/xwayland.c
+++ b/libweston-desktop/xwayland.c
@@ -170,6 +170,8 @@ weston_desktop_xwayland_surface_committed(struct weston_desktop_surface *dsurfac
 	if (surface->added)
 		weston_desktop_api_committed(surface->desktop, surface->surface,
 					     sx, sy);
+	else
+		weston_view_update_transform(surface->view);
 }
 
 static void


### PR DESCRIPTION
This address the issue that popup menu (often by right click) doesn't appear on screen until mouse pointer is moved. This issue is often observed with GTK based applications, such as sublime_text, when it's running in X11 mode (GDK_BACKEND=x11).