### PR TITLE
rdp backend/rdp shell: sync window state with RDP client

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -200,6 +200,13 @@ struct weston_rdp_shared_memory {
 	char name[RDP_SHARED_MEMORY_NAME_SIZE + 1]; // +1 for NULL
 };
 
+/* weston_surface_rail_state.showState_requested */
+#define RDP_WINDOW_HIDE 0x00
+#define RDP_WINDOW_SHOW_MINIMIZED 0x02
+#define RDP_WINDOW_SHOW_MAXIMIZED 0x03
+#define RDP_WINDOW_SHOW_FULLSCREEN 0x04
+#define RDP_WINDOW_SHOW 0x05
+
 struct weston_surface_rail_state {
 	struct wl_listener destroy_listener;
 	struct wl_listener repaint_listener;
@@ -217,12 +224,8 @@ struct weston_surface_rail_state {
 	uint32_t parent_window_id;
 	bool isCursor;
 	bool isWindowCreated;
-	bool is_minimized;
-	bool is_minimized_requested;
-	bool is_maximized;
-	bool is_maximized_requested;
-	bool is_fullscreen;
-	bool is_fullscreen_requested;
+	uint32_t showState_requested;
+	uint32_t showState;
 	bool forceRecreateSurface;
 	bool forceUpdateWindowState;
 	bool error;

--- a/libweston-desktop/xwayland.c
+++ b/libweston-desktop/xwayland.c
@@ -80,6 +80,13 @@ weston_desktop_xwayland_surface_change_state(struct weston_desktop_xwayland_surf
 	assert(!parent || state == TRANSIENT);
 
 	if (to_add && surface->added) {
+		/* at restoring from maximized/fullscreen, let shell knows */
+		if (state == TOPLEVEL) {
+			if (surface->state == MAXIMIZED)
+				weston_desktop_api_maximized_requested(surface->desktop, surface->surface, false);
+			else if (surface->state == FULLSCREEN)
+				weston_desktop_api_fullscreen_requested(surface->desktop, surface->surface, false, NULL);
+		}
 		surface->state = state;
 		return;
 	}

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -2499,7 +2499,11 @@ desktop_surface_committed(struct weston_desktop_surface *desktop_surface,
 		}
 
 		if (!shsurf->saved_showstate_valid) {
-			shsurf->saved_showstate = rail_state ? rail_state->showState : RDP_WINDOW_HIDE;
+			if (shsurf->state.fullscreen)
+				rail_state->showState_requested = RDP_WINDOW_SHOW_FULLSCREEN;
+			else
+				rail_state->showState_requested = RDP_WINDOW_SHOW_MAXIMIZED;
+			shsurf->saved_showstate = rail_state ? rail_state->showState : RDP_WINDOW_SHOW;
 			shsurf->saved_showstate_valid = true;
 		}
 

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -108,6 +108,8 @@ struct shell_surface {
 
 	int32_t saved_x, saved_y;
 	bool saved_position_valid;
+	uint32_t saved_showstate;
+	bool saved_showstate_valid;
 	bool saved_rotation_valid;
 	int unresponsive, grabbed;
 	uint32_t resize_edges;
@@ -1747,7 +1749,6 @@ unset_fullscreen(struct shell_surface *shsurf)
 
 	if (!rail_state)
 		return;
-	rail_state->is_fullscreen_requested = false;
 
 	/* Unset the fullscreen output, driver configuration and transforms. */
 	wl_list_remove(&shsurf->fullscreen.transform.link);
@@ -1756,6 +1757,12 @@ unset_fullscreen(struct shell_surface *shsurf)
 	if (shsurf->fullscreen.black_view)
 		weston_surface_destroy(shsurf->fullscreen.black_view->surface);
 	shsurf->fullscreen.black_view = NULL;
+
+	if (shsurf->saved_showstate_valid)
+		rail_state->showState_requested = shsurf->saved_showstate;
+	else
+		rail_state->showState_requested = RDP_WINDOW_SHOW;
+	shsurf->saved_showstate_valid = false;
 
 	if (shsurf->saved_position_valid)
 		weston_view_set_position(shsurf->view,
@@ -1769,6 +1776,7 @@ unset_fullscreen(struct shell_surface *shsurf)
 		               &shsurf->rotation.transform.link);
 		shsurf->saved_rotation_valid = false;
 	}
+
 }
 
 static void
@@ -1781,11 +1789,16 @@ unset_maximized(struct shell_surface *shsurf)
 
 	if (!rail_state)
 		return;
-	rail_state->is_maximized_requested = false;
 
 	/* if shell surface has already output assigned, leave where it is. (don't move to primary). */
 	if (!shsurf->output)
 		shell_surface_set_output(shsurf, get_default_output(surface->compositor));
+
+	if (shsurf->saved_showstate_valid)
+		rail_state->showState_requested = shsurf->saved_showstate;
+	else
+		rail_state->showState_requested = RDP_WINDOW_SHOW;
+	shsurf->saved_showstate_valid = false;
 
 	if (shsurf->snapped.is_snapped) {
 		/* Restore to snap state.
@@ -1825,11 +1838,15 @@ set_minimized(struct weston_surface *surface)
 
 	if (!rail_state)
 		return;
-	rail_state->is_minimized_requested = true;
 
 	assert(weston_surface_get_main_surface(view->surface) == view->surface);
 
 	shsurf = get_shell_surface(surface);
+
+	shsurf->saved_showstate = rail_state->showState;
+	shsurf->saved_showstate_valid = true;
+	rail_state->showState_requested = RDP_WINDOW_SHOW_MINIMIZED;
+
 	current_ws = get_current_workspace(shsurf->shell);
 
 	weston_layer_entry_remove(&view->layer_link);
@@ -1857,11 +1874,17 @@ set_unminimized(struct weston_surface *surface)
 
 	if (!rail_state)
 		return;
-	rail_state->is_minimized_requested = false;
 
 	assert(weston_surface_get_main_surface(view->surface) == view->surface);
 
 	shsurf = get_shell_surface(surface);
+
+	if (shsurf->saved_showstate_valid)
+		rail_state->showState_requested = shsurf->saved_showstate;
+	else
+		rail_state->showState_requested = RDP_WINDOW_SHOW;
+	shsurf->saved_showstate_valid = false;
+
 	current_ws = get_current_workspace(shsurf->shell);
 
 	weston_layer_entry_remove(&view->layer_link);
@@ -1874,7 +1897,15 @@ set_unminimized(struct weston_surface *surface)
 static void
 set_unsnap(struct shell_surface *shsurf, int grabX, int grabY)
 {
+	struct weston_surface *surface =
+		weston_desktop_surface_get_surface(shsurf->desktop_surface);
+	struct weston_surface_rail_state *rail_state =
+		(struct weston_surface_rail_state *)surface->backend_state;
+
 	if (!shsurf->snapped.is_snapped)
+		return;
+
+	if (!rail_state)
 		return;
 
 	/*
@@ -1887,6 +1918,8 @@ set_unsnap(struct shell_surface *shsurf, int grabX, int grabY)
 	}
 
 	weston_desktop_surface_set_size(shsurf->desktop_surface, shsurf->snapped.saved_width, shsurf->snapped.saved_height);*/
+	rail_state->showState_requested = RDP_WINDOW_SHOW;
+	shsurf->saved_showstate_valid = false;
 	shsurf->snapped.is_snapped = false;
 }
 
@@ -2207,6 +2240,7 @@ desktop_surface_added(struct weston_desktop_surface *desktop_surface,
 
 	shsurf->shell = shell;
 	shsurf->unresponsive = 0;
+	shsurf->saved_showstate_valid = false;
 	shsurf->saved_position_valid = false;
 	shsurf->saved_rotation_valid = false;
 	shsurf->desktop_surface = desktop_surface;
@@ -2421,6 +2455,8 @@ desktop_surface_committed(struct weston_desktop_surface *desktop_surface,
 		weston_desktop_surface_get_user_data(desktop_surface);
 	struct weston_surface *surface =
 		weston_desktop_surface_get_surface(desktop_surface);
+	struct weston_surface_rail_state *rail_state =
+		(struct weston_surface_rail_state *)surface->backend_state;
 	struct weston_view *view = shsurf->view;
 	struct desktop_shell *shell = data;
 	bool was_fullscreen;
@@ -2450,16 +2486,22 @@ desktop_surface_committed(struct weston_desktop_surface *desktop_surface,
 	    was_maximized == shsurf->state.maximized)
 	    return;
 
-	if (was_fullscreen)
+	if (was_fullscreen && !shsurf->state.fullscreen)
 		unset_fullscreen(shsurf);
-	if (was_maximized)
+	if (was_maximized && !shsurf->state.maximized)
 		unset_maximized(shsurf);
 
-	if ((shsurf->state.fullscreen || shsurf->state.maximized) &&
-	    !shsurf->saved_position_valid) {
-		shsurf->saved_x = shsurf->view->geometry.x;
-		shsurf->saved_y = shsurf->view->geometry.y;
-		shsurf->saved_position_valid = true;
+	if ((shsurf->state.fullscreen || shsurf->state.maximized)) {
+		if (!shsurf->saved_position_valid) {
+			shsurf->saved_x = shsurf->view->geometry.x;
+			shsurf->saved_y = shsurf->view->geometry.y;
+			shsurf->saved_position_valid = true;
+		}
+
+		if (!shsurf->saved_showstate_valid) {
+			shsurf->saved_showstate = rail_state ? rail_state->showState : RDP_WINDOW_HIDE;
+			shsurf->saved_showstate_valid = true;
+		}
 
 		if (!wl_list_empty(&shsurf->rotation.transform.link)) {
 			wl_list_remove(&shsurf->rotation.transform.link);
@@ -2541,9 +2583,14 @@ set_fullscreen(struct shell_surface *shsurf, bool fullscreen,
 
 	if (!rail_state)
 		return;
-	rail_state->is_fullscreen_requested = fullscreen;
 
 	if (fullscreen) {
+		/* if window is created as fullscreen, always set previous state as normal */
+		shsurf->saved_showstate = weston_surface_is_mapped(surface) ? \
+			rail_state->showState : RDP_WINDOW_SHOW;
+		shsurf->saved_showstate_valid = true;
+		rail_state->showState_requested = RDP_WINDOW_SHOW_FULLSCREEN;
+
 		/* handle clients launching in fullscreen */
 		if (output == NULL && !weston_surface_is_mapped(surface)) {
 			/* Set the output to the one that has focus currently. */
@@ -2556,8 +2603,18 @@ set_fullscreen(struct shell_surface *shsurf, bool fullscreen,
 		width = shsurf->output->width;
 		height = shsurf->output->height;
 	} else if (weston_desktop_surface_get_maximized(desktop_surface)) {
+		shsurf->saved_showstate = rail_state->showState;
+		shsurf->saved_showstate_valid = true;
+		rail_state->showState_requested = RDP_WINDOW_SHOW_MAXIMIZED;
 		get_maximized_size(shsurf, &width, &height);
+	} else {
+		if (shsurf->saved_showstate_valid)
+			rail_state->showState_requested = shsurf->saved_showstate;
+		else
+			rail_state->showState_requested = RDP_WINDOW_SHOW;
+		shsurf->saved_showstate_valid = false;
 	}
+
 	weston_desktop_surface_set_fullscreen(desktop_surface, fullscreen);
 	weston_desktop_surface_set_size(desktop_surface, width, height);
 }
@@ -2677,12 +2734,17 @@ set_maximized(struct shell_surface *shsurf, bool maximized)
 
 	if (!rail_state)
 		return;
-	rail_state->is_maximized_requested = maximized;
 
 	if (maximized) {
 		struct weston_output *output;
 
-		 if (!weston_surface_is_mapped(surface))
+		/* if window is created as maximized, always set previous state as normal */
+		shsurf->saved_showstate = weston_surface_is_mapped(surface) ? \
+			rail_state->showState : RDP_WINDOW_SHOW;
+		shsurf->saved_showstate_valid = true;
+		rail_state->showState_requested = RDP_WINDOW_SHOW_MAXIMIZED;
+
+		if (!weston_surface_is_mapped(surface))
 			output = get_focused_output(surface->compositor);
 		else
 			/* TODO: Need to revisit here for local move. */
@@ -2691,6 +2753,12 @@ set_maximized(struct shell_surface *shsurf, bool maximized)
 		shell_surface_set_output(shsurf, output);
 
 		get_maximized_size(shsurf, &width, &height);
+	} else {
+		if (shsurf->saved_showstate_valid)
+			rail_state->showState_requested = shsurf->saved_showstate;
+		else
+			rail_state->showState_requested = RDP_WINDOW_SHOW;
+		shsurf->saved_showstate_valid = false;
 	}
 	weston_desktop_surface_set_maximized(desktop_surface, maximized);
 	weston_desktop_surface_set_size(desktop_surface, width, height);
@@ -2728,6 +2796,11 @@ desktop_surface_set_window_icon(struct weston_desktop_surface *desktop_surface,
 static void
 shell_backend_request_window_minimize(struct weston_surface *surface)
 {
+	struct shell_surface *shsurf = get_shell_surface(surface);
+
+	if (!shsurf)
+		return;
+
 	set_minimized(surface);
 }
 
@@ -2776,9 +2849,16 @@ shell_backend_request_window_restore(struct weston_surface *surface)
 	if (!rail_state)
 		return;
 
-	if (rail_state->is_minimized_requested) {
+	if (rail_state->showState == RDP_WINDOW_SHOW_MINIMIZED) {
 		set_unminimized(surface);
-	} else 	if (shsurf->state.maximized) {
+	} else if (shsurf->state.fullscreen) {
+		/* fullscreen is treated as normal (aka restored) state in
+		   Windows client, thus there should be not be 'restore'
+		   request to be made while in fullscreen state. */
+		shell_rdp_debug(shsurf->shell,
+			 "%s: surface:%p is requested to be restored while in fullscreen\n",
+			__func__, surface);
+	} else if (shsurf->state.maximized) {
 		api = shsurf->shell->xwayland_surface_api;
 		if (!api) {
 			api = weston_xwayland_surface_get_api(shsurf->shell->compositor);

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -1215,6 +1215,13 @@ move_grab_motion(struct weston_pointer_grab *grab,
 	if (!shsurf)
 		return;
 
+	/* if local move is expected, but recieved the mouse move,
+	   then cacenl local move. */
+	if (shsurf->shell->is_localmove_pending) {
+		shell_rdp_debug(shsurf->shell, "%s: mouse move is detected while attempting local move\n", __func__);
+		shsurf->shell->is_localmove_pending = false;
+	}
+
 	surface = weston_desktop_surface_get_surface(shsurf->desktop_surface);
 
 	constrain_position(move, &cx, &cy);

--- a/xwayland/window-manager.c
+++ b/xwayland/window-manager.c
@@ -2100,14 +2100,17 @@ weston_wm_window_handle_state(struct weston_wm_window *window,
 	    update_state(action, &window->fullscreen)) {
 		weston_wm_window_set_net_wm_state(window);
 		if (window->fullscreen) {
-			window->saved_width = window->width;
-			window->saved_height = window->height;
-
+			if (!weston_wm_window_is_maximized(window)) {
+				window->saved_width = window->width;
+				window->saved_height = window->height;
+			}
 			if (window->shsurf)
 				xwayland_interface->set_fullscreen(window->shsurf,
 								   NULL);
-		} else {
-			if (window->shsurf)
+		} else if (window->shsurf) {
+			if (weston_wm_window_is_maximized(window))
+				xwayland_interface->set_maximized(window->shsurf);
+			else
 				weston_wm_window_set_toplevel(window);
 		}
 	} else {
@@ -2122,13 +2125,18 @@ weston_wm_window_handle_state(struct weston_wm_window *window,
 
 		if (maximized != weston_wm_window_is_maximized(window)) {
 			if (weston_wm_window_is_maximized(window)) {
-				window->saved_width = window->width;
-				window->saved_height = window->height;
-
+				if (!window->fullscreen) {
+					window->saved_width = window->width;
+					window->saved_height = window->height;
+				}
 				if (window->shsurf)
 					xwayland_interface->set_maximized(window->shsurf);
 			} else if (window->shsurf) {
-				weston_wm_window_set_toplevel(window);
+				if (window->fullscreen)
+					xwayland_interface->set_fullscreen(window->shsurf,
+									   NULL);
+				else
+					weston_wm_window_set_toplevel(window);
 			}
 		}
 	}
@@ -2511,9 +2519,14 @@ weston_wm_handle_button(struct weston_wm *wm, xcb_generic_event_t *event)
 		window->maximized_vert = !window->maximized_vert;
 		weston_wm_window_set_net_wm_state(window);
 		if (weston_wm_window_is_maximized(window)) {
-			window->saved_width = window->width;
-			window->saved_height = window->height;
+			if (!window->fullscreen) {
+				window->saved_width = window->width;
+				window->saved_height = window->height;
+			}
 			xwayland_interface->set_maximized(window->shsurf);
+		} else if (window->fullscreen) {
+			xwayland_interface->set_fullscreen(window->shsurf,
+							   NULL);
 		} else {
 			weston_wm_window_set_toplevel(window);
 		}
@@ -3196,26 +3209,32 @@ static void
 set_maximized(struct weston_surface *surface, bool is_maximized)
 {
 	struct weston_wm_window *window = get_wm_window(surface);
-	struct weston_wm *wm;
+	const struct weston_desktop_xwayland_interface *xwayland_interface;
 
 	if (!window || !window->wm)
 		return;
 
-	wm = window->wm;
+	xwayland_interface = window->wm->server->compositor->xwayland_interface;
 
 	if (is_maximized) {
 		if (!weston_wm_window_is_maximized(window)) {
 			window->maximized_horz = 1;
 			window->maximized_vert = 1;
-			window->saved_width = window->width;
-			window->saved_height = window->height;
-			wm->server->compositor->xwayland_interface->set_maximized(window->shsurf);
+			if (!window->fullscreen) {
+				window->saved_width = window->width;
+				window->saved_height = window->height;
+			}
+			xwayland_interface->set_maximized(window->shsurf);
 		}
 	} else {
 		if (weston_wm_window_is_maximized(window)) {
 			window->maximized_horz = 0;
 			window->maximized_vert = 0;
-			weston_wm_window_set_toplevel(window);
+			if (window->fullscreen)
+				xwayland_interface->set_fullscreen(window->shsurf,
+								   NULL);
+			else
+				weston_wm_window_set_toplevel(window);
 		}
 	}
 	weston_wm_window_set_net_wm_state(window);

--- a/xwayland/window-manager.c
+++ b/xwayland/window-manager.c
@@ -2149,8 +2149,10 @@ weston_wm_window_handle_iconic_state(struct weston_wm_window *window,
 	iconic_state = client_message->data.data32[0];
 
 	if (iconic_state == ICCCM_ICONIC_STATE) {
-		window->saved_height = window->height;
-		window->saved_width = window->width;
+		if (!weston_wm_window_is_maximized(window) && !window->fullscreen) {
+			window->saved_height = window->height;
+			window->saved_width = window->width;
+		}
 		xwayland_interface->set_minimized(window->shsurf);
 	}
 }
@@ -2519,8 +2521,10 @@ weston_wm_handle_button(struct weston_wm *wm, xcb_generic_event_t *event)
 	}
 
 	if (frame_status(window->frame) & FRAME_STATUS_MINIMIZE) {
-		window->saved_width = window->width;
-		window->saved_height = window->height;
+		if (!weston_wm_window_is_maximized(window) && !window->fullscreen) {
+			window->saved_width = window->width;
+			window->saved_height = window->height;
+		}
 		xwayland_interface->set_minimized(window->shsurf);
 		frame_status_clear(window->frame, FRAME_STATUS_MINIMIZE);
 	}


### PR DESCRIPTION
This PR address following issues.
- Win+Down arrow doesn't restore window when window is currently maximized.
- After maximizing then minimizing window, it doesn't restore to original non-maximized size.
- Keep tracking previous state before entering maximized/fullscreen state at  rdp shell.
- Add stub for sys menu callback.
- Address state transition between maximize and fullscreen state. After entering fullscreen from maximized, then restore, it does restore to maximized state. but not at correct position.