### PR TITLE
rdp backend/rdp shell: send window minmax info when window become visible

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -114,6 +114,10 @@ struct weston_rdprail_shell_api {
 	/** Query window geometry
 	  */
 	void (*get_window_geometry)(struct weston_surface *surface, struct weston_geometry *geometry);
+
+	/** Request to send window minmax info
+	  */
+	void (*request_window_minmax_info)(struct weston_surface *surface);
 };
 
 #define WESTON_RDPRAIL_API_NAME "weston_rdprail_api_v1"
@@ -134,6 +138,13 @@ struct weston_rdprail_app_list_data {
 	pixman_image_t *appIcon;
 };
 
+struct weston_rdp_rail_window_pos {
+	int32_t x;
+	int32_t y;
+	uint32_t width;
+	uint32_t height;
+};
+
 struct weston_rdprail_api {
 	/** Initialize
 	 */
@@ -144,12 +155,18 @@ struct weston_rdprail_api {
 	/** Start a local window move operation
 	 */
 	void (*start_window_move)(struct weston_surface *surface, 
-		int pointerGrabX, int pointerGrabY, 
-		struct weston_size minSize, struct weston_size maxSize);
+		int pointerGrabX, int pointerGrabY);
 
 	/** End local window move operation
 	 */
 	void (*end_window_move)(struct weston_surface *surface);
+
+	/** Send window min/max information.
+	 */
+	void (*send_window_minmax_info)(struct weston_surface* surface,
+		struct weston_rdp_rail_window_pos* maxPosSize,
+		struct weston_size* minTrackSize,
+		struct weston_size* maxTrackSize);
 
 	/** Set window icon
 	 */
@@ -183,13 +200,6 @@ weston_rdprail_get_api(struct weston_compositor *compositor)
 
 	return (const struct weston_rdprail_api *)api;
 }
-
-struct weston_rdp_rail_window_pos {
-	int32_t x;
-	int32_t y;
-	uint32_t width;
-	uint32_t height;
-};
 
 #define RDP_SHARED_MEMORY_NAME_SIZE (32 + 4 + 2)
 

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -384,8 +384,6 @@ void rdp_rail_peer_context_free(freerdp_peer *client, RdpPeerContext *context);
 void rdp_rail_output_repaint(struct weston_output *output, pixman_region32_t *damage);
 bool rdp_drdynvc_init(freerdp_peer *client);
 void rdp_drdynvc_destroy(RdpPeerContext *context);
-void rdp_rail_start_window_move(struct weston_surface *surface, int pointerGrabX, int pointerGrabY, struct weston_size minSize, struct weston_size maxSize);
-void rdp_rail_end_window_move(struct weston_surface *surface);
 
 // rdpdisp.c
 bool

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -542,7 +542,7 @@ rail_client_Syscommand_callback(bool freeOnly, void *arg)
 		break;
 	}
 
-	rdp_debug(b,
+	rdp_debug_verbose(b,
 		  "Client: ClientSyscommand: WindowId:0x%x, surface:0x%p, command:%s (0x%x)\n",
 		  syscommand->windowId, surface, commandString,
 		  syscommand->command);
@@ -3707,13 +3707,13 @@ rdp_rail_send_window_minmax_info(
 	minmax_order.maxTrackWidth = maxTrackSize->width;
 	minmax_order.maxTrackHeight = maxTrackSize->height;
 
-	rdp_debug(b,
+	rdp_debug_verbose(b,
 		  "Minmax order: maxPosX:%d, maxPosY:%d, maxWidth:%d, maxHeight:%d\n",
 		  minmax_order.maxPosX,
 		  minmax_order.maxPosY,
 		  minmax_order.maxWidth,
 		  minmax_order.maxHeight);
-	rdp_debug(b,
+	rdp_debug_verbose(b,
 		  "Minmax order: minTrackWidth:%d, minTrackHeight:%d, maxTrackWidth:%d, maxTrackHeight:%d\n",
 		  minmax_order.minTrackWidth,
 		  minmax_order.minTrackHeight,

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -2190,6 +2190,10 @@ rdp_rail_update_window(struct weston_surface *surface,
 				window_state_order.showState = WINDOW_HIDE;
 				break;
 			case RDP_WINDOW_SHOW:
+				/* if previoulsy hidden, send minmax info */
+				if (rail_state->showState == WINDOW_HIDE &&
+				    api && api->request_window_minmax_info)
+					api->request_window_minmax_info(surface);
 				window_state_order.showState = WINDOW_SHOW;
 				break;
 			case RDP_WINDOW_SHOW_MINIMIZED:
@@ -3656,13 +3660,61 @@ rdp_rail_sync_window_status(freerdp_peer *client)
 	weston_compositor_damage_all(b->compositor);
 }
 
-void
+static void
+rdp_rail_send_window_minmax_info(
+	struct weston_surface* surface,
+	struct weston_rdp_rail_window_pos* maxPosSize,
+	struct weston_size* minTrackSize,
+	struct weston_size* maxTrackSize)
+{
+	struct weston_compositor *compositor = surface->compositor;
+	struct weston_surface_rail_state *rail_state = surface->backend_state;
+	struct rdp_backend *b = to_rdp_backend(compositor);
+	RdpPeerContext *peer_ctx;
+	RailServerContext *rail_ctx;
+	RAIL_MINMAXINFO_ORDER minmax_order;
+
+	if (!b->rdp_peer || !b->rdp_peer->context->settings->HiDefRemoteApp) {
+		return;
+	}
+
+	peer_ctx = (RdpPeerContext *)b->rdp_peer->context;
+
+	/* Inform the RDP client about the minimum/maximum width and height allowed
+	 * on this window.
+	 */
+	minmax_order.windowId = rail_state->window_id;
+	minmax_order.maxPosX = maxPosSize->x;
+	minmax_order.maxPosY = maxPosSize->y;
+	minmax_order.maxWidth = maxPosSize->width;
+	minmax_order.maxHeight = maxPosSize->height;
+	minmax_order.minTrackWidth = minTrackSize->width;
+	minmax_order.minTrackHeight = minTrackSize->height;
+	minmax_order.maxTrackWidth = maxTrackSize->width;
+	minmax_order.maxTrackHeight = maxTrackSize->height;
+
+	rdp_debug(b,
+		  "Minmax order: maxPosX:%d, maxPosY:%d, maxWidth:%d, maxHeight:%d\n",
+		  minmax_order.maxPosX,
+		  minmax_order.maxPosY,
+		  minmax_order.maxWidth,
+		  minmax_order.maxHeight);
+	rdp_debug(b,
+		  "Minmax order: minTrackWidth:%d, minTrackHeight:%d, maxTrackWidth:%d, maxTrackHeight:%d\n",
+		  minmax_order.minTrackWidth,
+		  minmax_order.minTrackHeight,
+		  minmax_order.maxTrackWidth,
+		  minmax_order.maxTrackHeight);
+
+	rail_ctx = peer_ctx->rail_server_context;
+	rail_ctx->ServerMinMaxInfo(rail_ctx, &minmax_order);
+}
+
+static void
 rdp_rail_start_window_move(
 	struct weston_surface* surface,
 	int pointerGrabX,
-	int pointerGrabY,
-	struct weston_size minSize,
-	struct weston_size maxSize)
+	int pointerGrabY)
 {
 	struct weston_compositor *compositor = surface->compositor;
 	struct weston_surface_rail_state *rail_state = surface->backend_state;
@@ -3675,7 +3727,6 @@ rdp_rail_start_window_move(
 	struct rdp_backend *b = to_rdp_backend(compositor);
 	const struct weston_rdprail_shell_api *api = b->rdprail_shell_api;
 	RdpPeerContext *peer_ctx;
-	RAIL_MINMAXINFO_ORDER minmax_order;
 	RAIL_LOCALMOVESIZE_ORDER move_order;
 	int posX = 0, posY = 0;
 	int numViews = 0;
@@ -3713,47 +3764,14 @@ rdp_rail_start_window_move(
 	/* apply global to output transform, and translate to client coordinate */
 	if (surface->output) {
 		to_client_coordinate(peer_ctx, surface->output,
-				     &posX, &posY,
-				     &minSize.width, &minSize.height);
+				     &posX, &posY, NULL, NULL);
 		to_client_coordinate(peer_ctx, surface->output,
-				     &pointerGrabX, &pointerGrabY,
-				     &maxSize.width, &maxSize.height);
+				     &pointerGrabX, &pointerGrabY, NULL, NULL);
 	}
 
 	rdp_debug(b, "============== StartWindowMove ==============\n");
 	rdp_debug(b, "WindowsPosition: Pre-move (%d,%d) at client.\n", posX, posY);
 	rdp_debug(b, "pointerGrab: (%d,%d)\n", pointerGrabX, pointerGrabY);
-	rdp_debug(b, "minSize: (%dx%d)\n", minSize.width, minSize.height);
-	rdp_debug(b, "maxSize: (%dx%d)\n", maxSize.width, maxSize.height);
-
-	/* Inform the RDP client about the minimum/maximum width and height allowed
-	 * on this window.
-	 */
-	minmax_order.windowId = rail_state->window_id;
-	minmax_order.maxPosX = 0;
-	minmax_order.maxPosY = 0;
-	minmax_order.maxWidth = 0;
-	minmax_order.maxHeight = 0;
-	minmax_order.minTrackWidth = minSize.width;
-	minmax_order.minTrackHeight = minSize.height;
-	minmax_order.maxTrackWidth = maxSize.width;
-	minmax_order.maxTrackHeight = maxSize.height;
-
-	rdp_debug(b,
-		  "Minmax order: maxPosX:%d, maxPosY:%d, maxWidth:%d, maxHeight:%d\n",
-		  minmax_order.maxPosX,
-		  minmax_order.maxPosY,
-		  minmax_order.maxWidth,
-		  minmax_order.maxHeight);
-	rdp_debug(b,
-		  "Minmax order: minTrackWidth:%d, minTrackHeight:%d, maxTrackWidth:%d, maxTrackHeight:%d\n",
-		  minmax_order.minTrackWidth,
-		  minmax_order.minTrackHeight,
-		  minmax_order.maxTrackWidth,
-		  minmax_order.maxTrackHeight);
-
-	rail_ctx = peer_ctx->rail_server_context;
-	rail_ctx->ServerMinMaxInfo(rail_ctx, &minmax_order);
 
 	/* Start the local Window move.
 	 */
@@ -3771,12 +3789,13 @@ rdp_rail_start_window_move(
 		  move_order.posX,
 		  move_order.posY);
 
+	rail_ctx = peer_ctx->rail_server_context;
 	rail_ctx->ServerLocalMoveSize(rail_ctx, &move_order);
 
-	rdp_debug(b, "=============== StartWindowMove ===============\n");
+	rdp_debug(b, "============== StartWindowMove ==============\n");
 }
 
-void
+static void
 rdp_rail_end_window_move(struct weston_surface *surface)
 {
 	struct weston_compositor *compositor = surface->compositor;
@@ -4696,6 +4715,7 @@ struct weston_rdprail_api rdprail_api = {
 	.shell_initialize_notify = rdp_rail_shell_initialize_notify,
 	.start_window_move = rdp_rail_start_window_move,
 	.end_window_move = rdp_rail_end_window_move,
+	.send_window_minmax_info = rdp_rail_send_window_minmax_info,
 	.set_window_icon = rdp_rail_set_window_icon,
 #ifdef HAVE_FREERDP_RDPAPPLIST_H
 	.notify_app_list = rdp_rail_notify_app_list,


### PR DESCRIPTION
This PR contains.
- send window minmax info to RDP client when window become visible.
- minmax info should be always based on primary monitor as mentioned at https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-minmaxinfo.
- fix compile time warnings.