### PR TITLE
rdp backend: East Asian keyboard fixes

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -1007,6 +1007,11 @@ convert_rdp_keyboard_to_xkb_rule_names(
 		xkbRuleNames->layout = "us";
 		xkbRuleNames->variant = 0;
 	}
+	/* when no layout, default to "us" */
+	else if (!xkbRuleNames->layout) {
+		xkbRuleNames->layout = "us";
+		xkbRuleNames->variant = 0;
+	}
 
 	weston_log("%s: matching model=%s layout=%s variant=%s options=%s\n", __FUNCTION__,
 		xkbRuleNames->model, xkbRuleNames->layout, xkbRuleNames->variant, xkbRuleNames->options);

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -1008,7 +1008,7 @@ convert_rdp_keyboard_to_xkb_rule_names(
 		xkbRuleNames->variant = 0;
 	}
 	/* when no layout, default to "us" */
-	else if (!xkbRuleNames->layout) {
+	if (!xkbRuleNames->layout) {
 		xkbRuleNames->layout = "us";
 		xkbRuleNames->variant = 0;
 	}
@@ -1540,7 +1540,7 @@ xf_input_synchronize_event(rdpInput *input, UINT32 flags)
 static BOOL
 xf_input_keyboard_event(rdpInput *input, UINT16 flags, UINT16 code)
 {
-	uint32_t scan_code, vk_code, full_code;
+	uint32_t scan_code, vk_code, full_code, keyboard_locale;
 	enum wl_keyboard_key_state keyState;
 	freerdp_peer *client = input->context->peer;
 	RdpPeerContext *peerContext = (RdpPeerContext *)input->context;
@@ -1565,8 +1565,17 @@ xf_input_keyboard_event(rdpInput *input, UINT16 flags, UINT16 code)
 
 	if (keyboard && notify) {
 		full_code = code;
-		if (flags & KBD_FLAGS_EXTENDED)
+		/* On Windows 10 client, certain locale's keyboard layout reports extended 
+		   bit for right shift key (scancode 0x36) due to bug, so drop the bit here. */
+		keyboard_locale = client->context->settings->KeyboardLayout & 0xFFFF;
+		if (code == 0x36 && /* Right shift key */
+		    (keyboard_locale == KBD_CHINESE_TRADITIONAL_US ||
+		     keyboard_locale == KBD_CHINESE_SIMPLIFIED_US ||
+		     keyboard_locale == KBD_JAPANESE)) {
+			flags &= ~KBD_FLAGS_EXTENDED;
+		} else if (flags & KBD_FLAGS_EXTENDED) {
 			full_code |= KBD_FLAGS_EXTENDED;
+		}
 
 		/* Korean keyboard support */
 		/* WinPR's GetVirtualKeyCodeFromVirtualScanCode() can't handle hangul/hanja keys */

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -859,6 +859,12 @@ rail_client_LangbarInfo(RailServerContext *context,
 	return CHANNEL_RC_OK;
 }
 
+/* GUID_CHTIME_BOPOMOFO is not defined in FreeRDP */
+#define GUID_CHTIME_BOPOMOFO \
+{ \
+	0xB115690A, 0xEA02, 0x48D5, 0xA2, 0x31, 0xE3, 0x57, 0x8D, 0x2F, 0xDF, 0x80 \
+}
+
 static char *
 languageGuid_to_string(const GUID *guid)
 {
@@ -868,6 +874,7 @@ languageGuid_to_string(const GUID *guid)
 	static const struct lang_GUID c_GUID_KORIME = GUID_MSIME_KOR;
 	static const struct lang_GUID c_GUID_CHSIME = GUID_CHSIME;
 	static const struct lang_GUID c_GUID_CHTIME = GUID_CHTIME;
+	static const struct lang_GUID c_GUID_CHTIME_BOPOMOFO = GUID_CHTIME_BOPOMOFO;
 	static const struct lang_GUID c_GUID_PROFILE_NEWPHONETIC = GUID_PROFILE_NEWPHONETIC;
 	static const struct lang_GUID c_GUID_PROFILE_CHANGJIE = GUID_PROFILE_CHANGJIE;
 	static const struct lang_GUID c_GUID_PROFILE_QUICK = GUID_PROFILE_QUICK;
@@ -888,6 +895,8 @@ languageGuid_to_string(const GUID *guid)
 		return "GUID_CHSIME";
 	else if (UuidEqual(guid, (GUID *)&c_GUID_CHTIME, &rpc_status))
 		return "GUID_CHTIME";
+	else if (UuidEqual(guid, (GUID *)&c_GUID_CHTIME_BOPOMOFO, &rpc_status))
+		return "GUID_CHTIME_BOPOMOFO";
 	else if (UuidEqual(guid, (GUID *)&c_GUID_PROFILE_NEWPHONETIC, &rpc_status))
 		return "GUID_PROFILE_NEWPHONETIC";
 	else if (UuidEqual(guid, (GUID *)&c_GUID_PROFILE_CHANGJIE, &rpc_status))
@@ -920,7 +929,7 @@ rail_client_LanguageImeInfo_callback(bool freeOnly, void *arg)
 	struct rdp_backend *b = peer_ctx->rdpBackend;
 	uint32_t new_keyboard_layout = 0;
 	struct xkb_keymap *keymap = NULL;
-	struct xkb_rule_names xkbRuleNames;
+	struct xkb_rule_names xkbRuleNames = {};
 	char *s;
 
 	assert_compositor_thread(b);
@@ -957,6 +966,7 @@ rail_client_LanguageImeInfo_callback(bool freeOnly, void *arg)
 			static const struct lang_GUID c_GUID_KORIME = GUID_MSIME_KOR;
 			static const struct lang_GUID c_GUID_CHSIME = GUID_CHSIME;
 			static const struct lang_GUID c_GUID_CHTIME = GUID_CHTIME;
+			static const struct lang_GUID c_GUID_CHTIME_BOPOMOFO = GUID_CHTIME_BOPOMOFO;
 
 			RPC_STATUS rpc_status;
 			if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
@@ -970,6 +980,9 @@ rail_client_LanguageImeInfo_callback(bool freeOnly, void *arg)
 				new_keyboard_layout = KBD_CHINESE_SIMPLIFIED_US;
 			else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
 					   (GUID *)&c_GUID_CHTIME, &rpc_status))
+				new_keyboard_layout = KBD_CHINESE_TRADITIONAL_US;
+			else if (UuidEqual(&languageImeInfo->LanguageProfileCLSID,
+					   (GUID *)&c_GUID_CHTIME_BOPOMOFO, &rpc_status))
 				new_keyboard_layout = KBD_CHINESE_TRADITIONAL_US;
 			else
 				new_keyboard_layout = KBD_US;
@@ -988,6 +1001,8 @@ rail_client_LanguageImeInfo_callback(bool freeOnly, void *arg)
 					weston_seat_update_keymap(peer_ctx->item.seat, keymap);
 					xkb_keymap_unref(keymap);
 					settings->KeyboardLayout = new_keyboard_layout;
+					rdp_debug(b, "%s: new keyboard layout: 0x%x\n",
+						__func__, new_keyboard_layout);
 				}
 			}
 			if (!keymap) {


### PR DESCRIPTION
This PR addresses.
- default to US layout if no layout mapping is predefined.
- workaround extended bit is set for right shift on Windows 10 for Japanese/Chinese keyboard layout, this is reported at https://github.com/microsoft/wslg/issues/930.
- add case for Chinese Traditional Bopomofo keyboard layout. 