### PR TITLE
rdp backend: fix dispatch to display loop for clipboard

### DIFF
--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -367,9 +367,6 @@ void rdp_id_manager_for_each(struct rdp_id_manager *id_manager, hash_table_itera
 BOOL rdp_id_manager_allocate_id(struct rdp_id_manager *id_manager, void *object, UINT32 *new_id);
 void rdp_id_manager_free_id(struct rdp_id_manager *id_manager, UINT32 id);
 void dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* title);
-bool rdp_defer_rdp_task_to_display_loop(RdpPeerContext *peerCtx, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
-void rdp_defer_rdp_task_done(RdpPeerContext *peerCtx);
-bool rdp_event_loop_add_fd(struct wl_event_loop *loop, int fd, uint32_t mask, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source);
 void rdp_dispatch_task_to_display_loop(RdpPeerContext *peerCtx, rdp_loop_task_func_t func, struct rdp_loop_task *task);
 bool rdp_initialize_dispatch_task_event_source(RdpPeerContext *peerCtx);
 void rdp_destroy_dispatch_task_event_source(RdpPeerContext *peerCtx);

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -364,7 +364,7 @@ dump_id_manager_state(FILE *fp, struct rdp_id_manager *id_manager, char* title)
 	fprintf(fp,"\n");
 }
 
-bool
+static bool
 rdp_event_loop_add_fd(struct wl_event_loop *loop, int fd, uint32_t mask, wl_event_loop_fd_func_t func, void *data, struct wl_event_source **event_source)
 {
 	*event_source = wl_event_loop_add_fd(loop, fd, 0, func, data);


### PR DESCRIPTION
This PR reorganize the usage of utility functions to dispatch task to display loop thread. This address the issue identified at https://github.com/microsoft/wslg/issues/678#issuecomment-1452346653.

- queue deferred-task from display thread to display thread (with wait of file descriptor state change) use wl_event_loop_add_fd.
- dispatch task from non-display thread to display thread (with wait of file descriptor state change) use wl_event_loop_add_fd.
- dispatch task from non-display thread to display thread (dispatch immediately) use rdp_dispatch_task_to_display_loop.