### PR TITLE
rdp shell: fix overactive assert at launch_desktop_shell_process

### DIFF
--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -4138,7 +4138,10 @@ launch_desktop_shell_process(void *data)
 {
 	struct desktop_shell *shell = data;
 
-	assert(!shell->child.client);
+	/* check if it's already running */
+	if (shell->child.client)
+		return;
+
 	shell->child.client = weston_client_start(shell->compositor,
 						  shell->client);
 


### PR DESCRIPTION
This PR is to address the issue found at https://github.com/microsoft/wslg/issues/1000#issuecomment-1460755267, and this is the regression introduced at https://github.com/microsoft/weston-mirror/pull/128. Prior to this PR, shell process is launched once at shell initialization, but after that PR, shell process launch is deferred until the first surface reported to shell. When multiple surfaces are reported without processing Wayland idle event, it's possible multiple of event can be queued, and the assertion (which is converted to if) to be triggered at second event trigger.