### PR TITLE
rdp shell/rdp backend: drop window shadow when window is snapped

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -236,6 +236,7 @@ struct weston_surface_rail_state {
 	uint32_t parent_window_id;
 	bool isCursor;
 	bool isWindowCreated;
+	bool isWindowSnapped;
 	uint32_t showState_requested;
 	uint32_t showState;
 	bool forceRecreateSurface;

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -333,7 +333,7 @@ rail_client_SnapArrange_callback(bool freeOnly, void *arg)
 	pixman_rectangle32_t snap_rect;
 	struct weston_geometry geometry;
 
-	rdp_debug(b, "Client: SnapArrange: WindowId:0x%x at (%d, %d) %dx%d\n",
+	rdp_debug_verbose(b, "Client: SnapArrange: WindowId:0x%x at (%d, %d) %dx%d\n",
 		  snap->windowId,
 		  snap->left,
 		  snap->top,

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -1848,10 +1848,16 @@ unset_maximized(struct shell_surface *shsurf)
 	shsurf->saved_showstate_valid = false;
 
 	if (shsurf->snapped.is_snapped) {
-		/* Restore to snap state.
-		 */
-		weston_desktop_surface_set_size(shsurf->desktop_surface, shsurf->snapped.width, shsurf->snapped.height);
-		weston_view_set_position(shsurf->view, shsurf->snapped.x, shsurf->snapped.y);
+		/* If previously snapped state, don't go back to snap, but restore */
+		/* weston_desktop_surface_set_size() expects the size in window geometry coordinates */
+		/* saved_width and saved_height is already based on window geometry. */
+		weston_desktop_surface_set_size(
+			shsurf->desktop_surface,
+			shsurf->snapped.saved_width, shsurf->snapped.saved_height);
+		weston_view_set_position(shsurf->view, 
+			shsurf->snapped.saved_x, shsurf->snapped.saved_y);
+		shsurf->snapped.is_snapped = false;
+		rail_state->isWindowSnapped = false;
 	} else {
 		/* Restore to previous size or make up one if the window started maximized.
 		 */

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -1250,14 +1250,18 @@ move_grab_motion(struct weston_pointer_grab *grab,
 
 	/* if local move is expected, but recieved the mouse move,
 	   then cacenl local move. */
-	if (shsurf->shell->is_localmove_pending) {
+	if (shsurf->shell->is_localmove_pending &&
+		(pointer->grab_x != pointer->x ||
+		 pointer->grab_y != pointer->y)) {
 		shell_rdp_debug_verbose(shsurf->shell, "%s: mouse move is detected while attempting local move\n", __func__);
 		shsurf->shell->is_localmove_pending = false;
 	}
 
 	surface = weston_desktop_surface_get_surface(shsurf->desktop_surface);
 
-	if (shsurf->snapped.is_snapped) {
+	if (shsurf->snapped.is_snapped &&
+		(pointer->grab_x != pointer->x ||
+		 pointer->grab_y != pointer->y)) {
 		grab_unsnap_motion(grab);
 	} else {
 		constrain_position(move, &cx, &cy);


### PR DESCRIPTION
This PR contains 2 changes.
- Drop window shadow when window is snapped, so that snapped window perfectly aligns with monitor's edge.
- Restore window instead of snapped after window is unmaximized (after snapped then maximized) to mirror Windows behavior.