### PR TITLE
rdp backend: do not set window margin unless changed in window order PDU

### DIFF
--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -2090,7 +2090,7 @@ rdp_rail_update_window(struct weston_surface *surface,
 		/* drop window shadow area */
 		api->get_window_geometry(surface, &geometry);
 
-		if (!rail_state->isWindowSnapped) {
+		if (is_window_shadow_remoting_disabled(peer_ctx)) {
 			/* calculate window margin from input extents */
 			if (geometry.x > max(0, surface->input.extents.x1))
 				window_margin_left = geometry.x -
@@ -2301,11 +2301,14 @@ rdp_rail_update_window(struct weston_surface *surface,
 		}
 
 		if (is_window_shadow_remoting_disabled(peer_ctx)) {
-			if (rail_state->forceUpdateWindowState ||
-			    rail_state->window_margin_left != window_margin_left ||
-			    rail_state->window_margin_top != window_margin_top ||
-			    rail_state->window_margin_right != window_margin_right ||
-			    rail_state->window_margin_bottom != window_margin_bottom) {
+			/* Due to how mstsc/msrdc works, window margin must not be set
+			   while window is snapped unless they are changed. */
+			if ((rail_state->forceUpdateWindowState &&
+				!rail_state->isWindowSnapped) ||
+				rail_state->window_margin_left != window_margin_left ||
+				rail_state->window_margin_top != window_margin_top ||
+				rail_state->window_margin_right != window_margin_right ||
+				rail_state->window_margin_bottom != window_margin_bottom) {
 				/* add resize margin area */
 				window_order_info.fieldFlags |= WINDOW_ORDER_FIELD_RESIZE_MARGIN_X |
 								WINDOW_ORDER_FIELD_RESIZE_MARGIN_Y;


### PR DESCRIPTION
Do not set window margin unless it's changed in window order PDU while window is snapped. this causes window to be restored by mstsc/msrdc even set to same value as previously set.