### PR TITLE
rdp-backend: Fall back to weston.ini keymap if no mapping is found

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -1007,11 +1007,6 @@ convert_rdp_keyboard_to_xkb_rule_names(
 		xkbRuleNames->layout = "us";
 		xkbRuleNames->variant = 0;
 	}
-	/* when no layout, default to "us" */
-	if (!xkbRuleNames->layout) {
-		xkbRuleNames->layout = "us";
-		xkbRuleNames->variant = 0;
-	}
 
 	weston_log("%s: matching model=%s layout=%s variant=%s options=%s\n", __FUNCTION__,
 		xkbRuleNames->model, xkbRuleNames->layout, xkbRuleNames->variant, xkbRuleNames->options);

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -1001,6 +1001,14 @@ rail_client_LanguageImeInfo_callback(bool freeOnly, void *arg)
 						__func__, new_keyboard_layout,
 						settings->KeyboardType,
 						settings->KeyboardSubType);
+
+                                rdp_debug_error(b, "%s: Resetting default keymap\n", __func__);
+                                keymap = xkb_keymap_new_from_names(peer_ctx->item.seat->compositor->xkb_context,
+                                                                   &peer_ctx->item.seat->compositor->xkb_names,
+                                                                   0);
+                                weston_seat_update_keymap(peer_ctx->item.seat, keymap);
+                                xkb_keymap_unref(keymap);
+                                settings->KeyboardLayout = new_keyboard_layout;
 			}
 		}
 	}


### PR DESCRIPTION
When no keyboard mapping can be found at the moment we fallback to "us" layout preventing the user to use XKB layouts that have no Windows counterpart. We should instead fallback to the keymap in weston.ini and only fallback to us when no keymap is set there.

Should partially fix https://github.com/microsoft/wslg/issues/173 but it still needs an easy way to export weston.ini to the user. See also that issue for some example use cases for this pull request.