### PR TITLE
rdp-backend: Fix incorrect keyboard variant for Canadian French

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -957,7 +957,7 @@ struct rdp_to_xkb_keyboard_layout rdp_keyboards[] = {
 	{KBD_INUKTITUT_LATIN, "ca", "ike"},
 	{KBD_CANADIAN_FRENCH_LEGACY, "ca", "fr-legacy"},
 	{KBD_SERBIAN_CYRILLIC, "rs", 0},
-	{KBD_CANADIAN_FRENCH, "ca", "fr-legacy"},
+	{KBD_CANADIAN_FRENCH, "ca", 0},
 	{KBD_SWISS_FRENCH, "ch", "fr"},
 	{KBD_BOSNIAN, "ba", 0},
 	{KBD_IRISH, 0, 0},

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -955,7 +955,7 @@ struct rdp_to_xkb_keyboard_layout rdp_keyboards[] = {
 	{KBD_SWEDISH_WITH_SAMI, "se", "smi"},
 	{KBD_UZBEK_CYRILLIC, "af", "uz"},
 	{KBD_INUKTITUT_LATIN, "ca", "ike"},
-	{KBD_CANADIAN_FRENCH_LEGACY, "ca", 0},
+	{KBD_CANADIAN_FRENCH_LEGACY, "ca", "fr-legacy"},
 	{KBD_SERBIAN_CYRILLIC, "rs", 0},
 	{KBD_CANADIAN_FRENCH, "ca", "fr-legacy"},
 	{KBD_SWISS_FRENCH, "ch", "fr"},

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -955,7 +955,7 @@ struct rdp_to_xkb_keyboard_layout rdp_keyboards[] = {
 	{KBD_SWEDISH_WITH_SAMI, "se", "smi"},
 	{KBD_UZBEK_CYRILLIC, "af", "uz"},
 	{KBD_INUKTITUT_LATIN, "ca", "ike"},
-	{KBD_CANADIAN_FRENCH_LEGACY, "ca", "fr-legacy"},
+	{KBD_CANADIAN_FRENCH_LEGACY, "ca", 0},
 	{KBD_SERBIAN_CYRILLIC, "rs", 0},
 	{KBD_CANADIAN_FRENCH, "ca", "fr-legacy"},
 	{KBD_SWISS_FRENCH, "ch", "fr"},


### PR DESCRIPTION
The Canadian French RDP keyboard mapping to XKB is currently incorrect in WSLg. While it should resolve to layout 'ca' without any variant (Canadian French, https://learn.microsoft.com/en-us/globalization/keyboards/kbdca), it instead resolves as layout 'ca' variant 'fr-legacy' (Canadian French (Legacy), https://learn.microsoft.com/en-us/globalization/keyboards/kbdfc), which is already defined in the mapping for `KBD_CANADIAN_FRENCH_LEGACY`. This PR makes the correction.

Note that I didn't run nor test the code. I believe the correction is OK, but it should be validated. Thanks!