### PR TITLE
rdp backend/rdprail shell: fix maximizing window disappear

### DIFF
--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -46,6 +46,9 @@ struct weston_rdp_output_api {
 
 	/** Set mode for an output */
 	void (*output_set_mode)(struct weston_output *base, struct weston_mode *mode);
+
+	/** Get primary output */
+	struct weston_output *(*output_get_primary)(struct weston_compositor *compositor);
 };
 
 static inline const struct weston_rdp_output_api *

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -450,6 +450,22 @@ rdp_head_get_rdpmonitor(const struct weston_head *base)
 	return &h->config;
 }
 
+struct weston_output *
+rdp_output_get_primary(struct weston_compositor *compositor)
+{
+	struct rdp_backend *b = to_rdp_backend(compositor);
+	struct weston_head *iter;
+	wl_list_for_each(iter, &compositor->head_list, compositor_link) {
+		rdpMonitor *cur = rdp_head_get_rdpmonitor(iter);
+		if (cur->is_primary)
+			return iter->output;
+	}
+
+	rdp_debug_error(b, "%s: Didn't find primary output, return the first one\n", __func__);
+	return container_of(compositor->output_list.next,
+			    struct weston_output, link);
+}
+
 static int
 rdp_output_enable(struct weston_output *base)
 {
@@ -1992,6 +2008,7 @@ rdp_generate_session_tls(struct rdp_backend *b)
 static const struct weston_rdp_output_api api = {
 	rdp_head_get_rdpmonitor,
 	rdp_output_set_mode,
+	rdp_output_get_primary,
 };
 
 static int create_vsock_fd(int port)

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -340,6 +340,7 @@ struct rdp_loop_task {
 void convert_rdp_keyboard_to_xkb_rule_names(UINT32 KeyboardType, UINT32 KeyboardSubType, UINT32 KeyboardLayout, struct xkb_rule_names *xkbRuleNames);
 struct rdp_head * rdp_head_create(struct weston_compositor *compositor, BOOL isPrimary, rdpMonitor *config);
 void rdp_head_destroy(struct weston_compositor *compositor, struct rdp_head *head);
+struct weston_output *rdp_output_get_primary(struct weston_compositor *compositor);
 
 // rdputil.c
 pid_t rdp_get_tid(void);

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -3707,6 +3707,7 @@ rdp_rail_send_window_minmax_info(
 	struct weston_compositor *compositor = surface->compositor;
 	struct weston_surface_rail_state *rail_state = surface->backend_state;
 	struct rdp_backend *b = to_rdp_backend(compositor);
+	struct weston_output *output = rdp_output_get_primary(compositor);
 	RdpPeerContext *peer_ctx;
 	RailServerContext *rail_ctx;
 	RAIL_MINMAXINFO_ORDER minmax_order;
@@ -3719,14 +3720,16 @@ rdp_rail_send_window_minmax_info(
 	peer_ctx = (RdpPeerContext *)b->rdp_peer->context;
 
 	/* apply global to output transform, and translate to client coordinate */
-	if (surface->output) {
-		to_client_coordinate(peer_ctx, surface->output,
+	/* minmax info is based on primary monitor */
+	/* https://learn.microsoft.com/en-us/windows/win32/api/winuser/ns-winuser-minmaxinfo */
+	if (output) {
+		to_client_coordinate(peer_ctx, output,
 				     &maxPosSize->x, &maxPosSize->y,
 				     &maxPosSize->width, &maxPosSize->height);
-		to_client_coordinate(peer_ctx, surface->output,
+		to_client_coordinate(peer_ctx, output,
 				     &dummyX, &dummyY,
 				     &minTrackSize->width, &minTrackSize->height);
-		to_client_coordinate(peer_ctx, surface->output,
+		to_client_coordinate(peer_ctx, output,
 				     &dummyX, &dummyY,
 				     &maxTrackSize->width, &maxTrackSize->height);
 	}

--- a/rdprail-shell/shell.c
+++ b/rdprail-shell/shell.c
@@ -541,8 +541,8 @@ shell_send_minmax_info(struct weston_surface *surface)
 		output = get_default_output(shell->compositor);
 		assert(output);
 
-		maxPosSize.x = 0;
-		maxPosSize.y = 0;
+		maxPosSize.x = output->x;
+		maxPosSize.y = output->y;
 		maxPosSize.width = output->width;
 		maxPosSize.height = output->height;
 
@@ -848,11 +848,8 @@ shell_configuration(struct desktop_shell *shell)
 struct weston_output *
 get_default_output(struct weston_compositor *compositor)
 {
-	if (wl_list_empty(&compositor->output_list))
-		return NULL;
-
-	return container_of(compositor->output_list.next,
-			    struct weston_output, link);
+	const struct weston_rdp_output_api *api = weston_rdp_output_get_api(compositor);
+	return api->output_get_primary(compositor);
 }
 
 static struct weston_output *
@@ -2935,6 +2932,10 @@ set_maximized(struct shell_surface *shsurf, bool maximized)
 		shsurf->maximized.saved_surface_width = surface->width;
 		shsurf->maximized.saved_width = geometry.width;
 		shsurf->maximized.saved_height = geometry.height;
+
+		/* send current minmax info to client */
+		shell_send_minmax_info
+			(weston_desktop_surface_get_surface(shsurf->desktop_surface));
 	} else {
 		if (shsurf->saved_showstate_valid)
 			rail_state->showState_requested = shsurf->saved_showstate;


### PR DESCRIPTION
This PR to fix the issue the maximizing window to be disappeared which is reported at https://github.com/microsoft/wslg/issues/1058. This was due to the minmax info is not properly send to Windows client prior to maximizing window, and minmax must be based on primary monitor from Windows. Previously, rdprail-shell considers the first output in compositor's link-list which is not always primary output from Windows.