### PR TITLE
rdp shell: add scalable flatpak icons to start menu

### DIFF
--- a/rdprail-shell/app-list.c
+++ b/rdprail-shell/app-list.c
@@ -147,6 +147,7 @@ char *icon_folder[] = {
 	"/usr/share/icons/HighContrast/22x22/apps/",
 	"/usr/share/icons/HighContrast/16x16/apps/",
 	"/usr/share/icons/hicolor/scalable/apps/", /* use scalable(= svg) only when no png. */
+	"/var/lib/flatpak/exports/share/icons/hicolor/scalable/apps/", /* use scalable(= svg) only when no png. */
 	"/usr/share/icons/HighContrast/scalable/apps/", /* use scalable (= svg) only when no png. */
 };
 


### PR DESCRIPTION
Continuation of #135 to search the scalable folder for flatpak icons