### PR TITLE
rdp backend: waking up compositor after RDP connection is restored

### DIFF
--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -3629,6 +3629,7 @@ rdp_rail_sync_window_status(freerdp_peer *client)
 	RailServerContext *rail_ctx = peer_ctx->rail_server_context;
 	rdpUpdate *update = b->rdp_peer->context->update;
 	struct weston_view *view;
+	bool anyWindowCreated = false;
 
 	assert_compositor_thread(b);
 
@@ -3729,11 +3730,15 @@ rdp_rail_sync_window_status(freerdp_peer *client)
 						rdp_rail_create_window(NULL, sub->surface);
 				}
 			}
+			anyWindowCreated = true;
 		}
 	}
 
 	/* this assume repaint to be scheduled on idle loop, not directly from here */
-	weston_compositor_damage_all(b->compositor);
+	if (anyWindowCreated) {
+		weston_compositor_wake(b->compositor);
+		weston_compositor_damage_all(b->compositor);
+	}
 }
 
 static void


### PR DESCRIPTION
This PR to address the issue reported at https://github.com/microsoft/wslg/issues/1092, particularly address the first issue described at https://github.com/microsoft/wslg/issues/1092#issuecomment-1861445116.

When network configuration is changed at Windows, that causes RDP connection between Windows and WSL to lost, and that also leads to terminate the msrdc.exe. While msrdc.exe will be auto-relaunched by WSLg, but weston compositor does not repaint all window because it might be in "sleeping" state. This PR force waking up the compositor if there is any window opened when the RDP connection is restored.