### PR TITLE
rdp-backend: maintain wl-seat even RDP is disconnected

### DIFF
--- a/compositor/main.c
+++ b/compositor/main.c
@@ -2705,7 +2705,7 @@ weston_rdp_backend_config_init(struct weston_rdp_backend_config *config)
 	config->no_clients_resize = 0;
 	config->force_no_compression = 0;
 	config->redirect_clipboard = false;
-	config->enable_persistent_seat = false;
+	config->enable_persistent_rail_seat = false;
 	config->audio_in_setup = NULL;
 	config->audio_in_teardown = NULL;
 	config->audio_out_setup = NULL;
@@ -2830,7 +2830,7 @@ load_rdp_backend(struct weston_compositor *c,
 	/* certain configurations are read from environment variables */
 	config.redirect_clipboard = read_rdp_config_bool("WESTON_RDP_CLIPBOARD", true);
 
-	config.enable_persistent_seat = read_rdp_config_bool("WESTON_RDP_PERSISTENT_SEAT", true);
+	config.enable_persistent_rail_seat = read_rdp_config_bool("WESTON_RDP_PERSISTENT_RAIL_SEAT", true);
 
 	audio_tmp = read_rdp_config_bool("WESTON_RDP_AUDIO_PLAYBACK", true);
 	if (audio_tmp) {

--- a/compositor/main.c
+++ b/compositor/main.c
@@ -2705,6 +2705,7 @@ weston_rdp_backend_config_init(struct weston_rdp_backend_config *config)
 	config->no_clients_resize = 0;
 	config->force_no_compression = 0;
 	config->redirect_clipboard = false;
+	config->enable_persistent_seat = false;
 	config->audio_in_setup = NULL;
 	config->audio_in_teardown = NULL;
 	config->audio_out_setup = NULL;
@@ -2828,6 +2829,8 @@ load_rdp_backend(struct weston_compositor *c,
 
 	/* certain configurations are read from environment variables */
 	config.redirect_clipboard = read_rdp_config_bool("WESTON_RDP_CLIPBOARD", true);
+
+	config.enable_persistent_seat = read_rdp_config_bool("WESTON_RDP_PERSISTENT_SEAT", true);
 
 	audio_tmp = read_rdp_config_bool("WESTON_RDP_AUDIO_PLAYBACK", true);
 	if (audio_tmp) {

--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -283,7 +283,7 @@ struct weston_rdp_backend_config {
 	int no_clients_resize;
 	int force_no_compression;
 	bool redirect_clipboard;
-	bool enable_persistent_seat;
+	bool enable_persistent_rail_seat;
 	rdp_audio_in_setup audio_in_setup;
 	rdp_audio_in_teardown audio_in_teardown;
 	rdp_audio_out_setup audio_out_setup;

--- a/include/libweston/backend-rdp.h
+++ b/include/libweston/backend-rdp.h
@@ -283,6 +283,7 @@ struct weston_rdp_backend_config {
 	int no_clients_resize;
 	int force_no_compression;
 	bool redirect_clipboard;
+	bool enable_persistent_seat;
 	rdp_audio_in_setup audio_in_setup;
 	rdp_audio_in_teardown audio_in_teardown;
 	rdp_audio_out_setup audio_out_setup;

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -664,6 +664,9 @@ rdp_destroy(struct weston_compositor *ec)
 		b->debug = NULL;
 	}
 
+	if (b->persistent_rail_seat)
+		weston_seat_release(b->persistent_rail_seat);
+
 	weston_compositor_shutdown(ec);
 
 	wl_list_for_each_safe(base, next, &ec->head_list, compositor_link)

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -671,7 +671,7 @@ rdp_destroy(struct weston_compositor *ec)
 
 	freerdp_listener_free(b->listener);
 
-	free(b->persistent_seat);
+	free(b->persistent_rail_seat);
 	free(b->server_cert);
 	free(b->server_key);
 	free(b->rdp_key);
@@ -805,9 +805,9 @@ rdp_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 		weston_seat_release_pointer(context->item.seat);
 		/* save current seat for future use only when it's not saved yet */
 		if (settings->RemoteApplicationMode &&
-			b->enable_persistent_seat &&
-		       	!b->persistent_seat) {
-			b->persistent_seat = context->item.seat;
+			b->enable_persistent_rail_seat) {
+			assert(!b->persistent_rail_seat);
+			b->persistent_rail_seat = context->item.seat;
 		} else {
 			weston_seat_release(context->item.seat);
 			free(context->item.seat);
@@ -1205,7 +1205,12 @@ xf_peer_activate(freerdp_peer* client)
 	else
 		snprintf(seat_name, sizeof(seat_name), "RDP peer @%s", settings->ClientAddress);
 
-	if (!b->persistent_seat) {
+	if (settings->RemoteApplicationMode &&
+		b->persistent_rail_seat) {
+		/* reuse persistent seat for RAIL connection */
+		peersItem->seat = b->persistent_rail_seat;
+		b->persistent_rail_seat = NULL;
+	} else {
 		peersItem->seat = zalloc(sizeof(*peersItem->seat));
 		if (!peersItem->seat) {
 			xkb_keymap_unref(keymap);
@@ -1213,9 +1218,6 @@ xf_peer_activate(freerdp_peer* client)
 			goto error_exit;
 		}
 		weston_seat_init(peersItem->seat, b->compositor, seat_name);
-	} else {
-		peersItem->seat = b->persistent_seat;
-		b->persistent_seat = NULL;
 	}
 
 	weston_seat_init_keyboard(peersItem->seat, keymap);
@@ -2128,7 +2130,7 @@ rdp_backend_create(struct weston_compositor *compositor,
 	b->no_clients_resize = config->no_clients_resize;
 	b->force_no_compression = config->force_no_compression;
 	b->redirect_clipboard = config->redirect_clipboard;
-	b->enable_persistent_seat = config->enable_persistent_seat;
+	b->enable_persistent_rail_seat = config->enable_persistent_rail_seat;
 	b->rdp_monitor_refresh_rate = config->rdp_monitor_refresh_rate * 1000;
 	b->audio_in_setup = config->audio_in_setup;
 	b->audio_in_teardown = config->audio_in_teardown;
@@ -2316,7 +2318,7 @@ config_init_to_defaults(struct weston_rdp_backend_config *config)
 	config->no_clients_resize = 0;
 	config->force_no_compression = 0;
 	config->redirect_clipboard = false;
-	config->enable_persistent_seat = false;
+	config->enable_persistent_rail_seat = false;
 	config->rdp_monitor_refresh_rate = WESTON_RDP_MODE_FREQ;
 	config->rail_config.use_rdpapplist = false;
 	config->rail_config.use_shared_memory = false;

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -671,6 +671,7 @@ rdp_destroy(struct weston_compositor *ec)
 
 	freerdp_listener_free(b->listener);
 
+	free(b->persistent_seat);
 	free(b->server_cert);
 	free(b->server_key);
 	free(b->rdp_key);
@@ -800,8 +801,13 @@ rdp_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 	if (context->item.flags & RDP_PEER_ACTIVATED) {
 		weston_seat_release_keyboard(context->item.seat);
 		weston_seat_release_pointer(context->item.seat);
-		weston_seat_release(context->item.seat);
-		free(context->item.seat);
+		if (b->enable_persistent_seat && !b->persistent_seat) {
+			/* save current seat for future use only when it's not saved yet */
+			b->persistent_seat = context->item.seat;
+		} else {
+			weston_seat_release(context->item.seat);
+			free(context->item.seat);
+		}
 		context->item.seat = NULL;
 		context->item.flags &= ~RDP_PEER_ACTIVATED;
 	}
@@ -1193,14 +1199,19 @@ xf_peer_activate(freerdp_peer* client)
 	else
 		snprintf(seat_name, sizeof(seat_name), "RDP peer @%s", settings->ClientAddress);
 
-	peersItem->seat = zalloc(sizeof(*peersItem->seat));
-	if (!peersItem->seat) {
-		xkb_keymap_unref(keymap);
-		rdp_debug_error(b, "unable to create a weston_seat\n");
-		goto error_exit;
+	if (!b->persistent_seat) {
+		peersItem->seat = zalloc(sizeof(*peersItem->seat));
+		if (!peersItem->seat) {
+			xkb_keymap_unref(keymap);
+			rdp_debug_error(b, "unable to create a weston_seat\n");
+			goto error_exit;
+		}
+		weston_seat_init(peersItem->seat, b->compositor, seat_name);
+	} else {
+		peersItem->seat = b->persistent_seat;
+		b->persistent_seat = NULL;
 	}
 
-	weston_seat_init(peersItem->seat, b->compositor, seat_name);
 	weston_seat_init_keyboard(peersItem->seat, keymap);
 	xkb_keymap_unref(keymap);
 	weston_seat_init_pointer(peersItem->seat);
@@ -2111,6 +2122,7 @@ rdp_backend_create(struct weston_compositor *compositor,
 	b->no_clients_resize = config->no_clients_resize;
 	b->force_no_compression = config->force_no_compression;
 	b->redirect_clipboard = config->redirect_clipboard;
+	b->enable_persistent_seat = config->enable_persistent_seat;
 	b->rdp_monitor_refresh_rate = config->rdp_monitor_refresh_rate * 1000;
 	b->audio_in_setup = config->audio_in_setup;
 	b->audio_in_teardown = config->audio_in_teardown;
@@ -2298,6 +2310,7 @@ config_init_to_defaults(struct weston_rdp_backend_config *config)
 	config->no_clients_resize = 0;
 	config->force_no_compression = 0;
 	config->redirect_clipboard = false;
+	config->enable_persistent_seat = false;
 	config->rdp_monitor_refresh_rate = WESTON_RDP_MODE_FREQ;
 	config->rail_config.use_rdpapplist = false;
 	config->rail_config.use_shared_memory = false;

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -760,12 +760,14 @@ static void
 rdp_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 {
 	struct rdp_backend *b;
+	rdpSettings *settings;
 	unsigned i;
 
 	if (!context)
 		return;
 
 	b = context->rdpBackend;
+	settings = client->context->settings;
 
 	/* While RDP client is disconnected, keep compositor sleep state */
 	weston_compositor_sleep(b->compositor);
@@ -801,8 +803,10 @@ rdp_peer_context_free(freerdp_peer* client, RdpPeerContext* context)
 	if (context->item.flags & RDP_PEER_ACTIVATED) {
 		weston_seat_release_keyboard(context->item.seat);
 		weston_seat_release_pointer(context->item.seat);
-		if (b->enable_persistent_seat && !b->persistent_seat) {
-			/* save current seat for future use only when it's not saved yet */
+		/* save current seat for future use only when it's not saved yet */
+		if (settings->RemoteApplicationMode &&
+			b->enable_persistent_seat &&
+		       	!b->persistent_seat) {
 			b->persistent_seat = context->item.seat;
 		} else {
 			weston_seat_release(context->item.seat);
@@ -1194,6 +1198,8 @@ xf_peer_activate(freerdp_peer* client)
 						   &xkbRuleNames, 0);
 	}
 
+	if (settings->RemoteApplicationMode)
+		snprintf(seat_name, sizeof(seat_name), "RDP Remote Application Client");
 	if (settings->ClientHostname)
 		snprintf(seat_name, sizeof(seat_name), "RDP %s", settings->ClientHostname);
 	else

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -107,6 +107,7 @@ struct rdp_backend {
 	int no_clients_resize;
 	int force_no_compression;
 	bool redirect_clipboard;
+	bool enable_persistent_seat;
 	rdp_audio_in_setup audio_in_setup;
 	rdp_audio_in_teardown audio_in_teardown;
 	rdp_audio_out_setup audio_out_setup;
@@ -119,6 +120,7 @@ struct rdp_backend {
 	bool enable_distro_name_title;
 
 	freerdp_peer *rdp_peer; // this points a single instance of RAIL RDP peer.
+	struct weston_seat *persistent_seat; // Saved for persistent seat
 	pid_t compositor_tid;
 
 	struct weston_binding *debug_binding_M;

--- a/libweston/backend-rdp/rdp.h
+++ b/libweston/backend-rdp/rdp.h
@@ -107,7 +107,7 @@ struct rdp_backend {
 	int no_clients_resize;
 	int force_no_compression;
 	bool redirect_clipboard;
-	bool enable_persistent_seat;
+	bool enable_persistent_rail_seat;
 	rdp_audio_in_setup audio_in_setup;
 	rdp_audio_in_teardown audio_in_teardown;
 	rdp_audio_out_setup audio_out_setup;
@@ -120,7 +120,7 @@ struct rdp_backend {
 	bool enable_distro_name_title;
 
 	freerdp_peer *rdp_peer; // this points a single instance of RAIL RDP peer.
-	struct weston_seat *persistent_seat; // Saved for persistent seat
+	struct weston_seat *persistent_rail_seat; // Saved for persistent seat
 	pid_t compositor_tid;
 
 	struct weston_binding *debug_binding_M;


### PR DESCRIPTION
This PR changes wl-seat is no longer removed when RDP is disconnected. There are several Wayland-native applications (mainly GDK apps) don't handle wl-seat removal and arrival dynamically, and it causes such applications to no longer accept input from mouse/keyboard after RDP reconnection. This PR workarounds the issue by maintaining wl-seat even RDP is disconnected at, such as, system sleep and network configuration changes where, by default, RDP resets its connection.