### PR TITLE
Bump Weston metadata to 14.0.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('weston',
 	'c',
-	version: '9.0.0',
+	version: '14.0.2',
 	default_options: [
 		'warning_level=3',
 		'c_std=gnu99',
@@ -10,7 +10,7 @@ project('weston',
 	license: 'MIT/Expat',
 )
 
-libweston_major = 9
+libweston_major = 14
 
 # libweston_revision is manufactured to follow the autotools build's
 # library file naming, thanks to libtool


### PR DESCRIPTION
- Fixes https://github.com/microsoft/wslg/issues/1349 .
- Fixes https://github.com/microsoft/wslg/issues/1345 .
- Bump Weston metadata to 14.0.2 .
- This should also alleviate the issue at https://github.com/zed-industries/zed/issues/47128 and https://github.com/microsoft/wslg/issues/1345 . zed hardcodes a lot of abstract system dependency checks.
- However, updating Weston will make some changes to the visuals. See https://github.com/qq1038765585/wslg_title_bar_beautify . The current effect of wslg is as follows.
- <img width="1344" height="149" alt="image" src="https://github.com/user-attachments/assets/941a1c35-b7f3-4cc7-8321-13438b57a514" />
- After merging this PR, wslg will support Dark mode. See https://github.com/qq1038765585/wslg_title_bar_beautify?tab=readme-ov-file#lightdark-switch . Of course, the changes at https://github.com/microsoft/weston-mirror/pull/129 and https://gitlab.freedesktop.org/wayland/weston/-/merge_requests/1154 are not discussed in the current PR.



