### PR TITLE
rdprail-shell: unshare(CLONE_FS) before every setns to fix app-list cascade

### DIFF
--- a/rdprail-shell/app-list.c
+++ b/rdprail-shell/app-list.c
@@ -205,6 +205,13 @@ attach_app_list_namespace(struct desktop_shell *shell)
 	assert(false == context->isAppListNamespaceAttached);
 	if (context && context->app_list_pidfd >= 0) {
 		assert(context->weston_pidfd >= 0);
+		/* Worker threads spawned by libraries (e.g. librsvg/rayon) re-share
+		 * fs_struct via pthread_create's CLONE_FS; setns(CLONE_NEWNS) needs
+		 * fs->users == 1, so unshare here before every setns. */
+		if (unshare(CLONE_FS) == -1) {
+			shell_rdp_debug_error(shell, "attach_app_list_namespace: unshare(CLONE_FS) failed %s\n", strerror(errno));
+			return;
+		}
 		if (setns(context->app_list_pidfd, 0) == -1) {
 			shell_rdp_debug_error(shell, "attach_app_list_namespace failed %s\n", strerror(errno));
 		} else {


### PR DESCRIPTION
## Problem

After the WSLg system distro moved from CBL-Mariner 2.0 to Azure Linux 3 (WSLg 1.0.72 / shipped in WSL 2.7.3), most user-distro GUI apps stop appearing in the Start menu. `weston.log` shows the first `setns()` succeed, then the very next `attach_app_list_namespace` and every one after fail with `Invalid argument`, forever:

```
[19:56:04.719] rdp_rail_notify_app_list (audacity)         OK
[19:56:11.892] file created/updated (gimp.desktop)
[19:56:11.892] attach_app_list_namespace failed Invalid argument
[19:56:11.974] attach_app_list_namespace failed Invalid argument
[19:56:15.030] attach_app_list_namespace failed Invalid argument
... (forever)
```

Reported in microsoft/wslg#1444 and microsoft/WSL#40538.

## Root cause

After `app_list_monitor_thread` calls `detach_app_list_namespace`, it rasterises SVG icons with `load_image_svg()` -> librsvg.

librsvg 2.55+ uses `rayon` for parallel filter/pattern/gradient/mask processing, and **lazily creates its global rayon `ThreadPool` the first time it actually needs the parallel renderer**. Simple flat single-path SVGs (e.g. Adwaita-style GNOME icons - `gnome-calculator`, `gnome-clocks`, `eog`, ...) render entirely on librsvg's C path and never trigger this. **Richer SVGs that exercise filters / gradients / masks (Audacity, GIMP, JetBrains, Discord, ...) do.**

When that first complex SVG is processed, rayon spawns its pool from inside `app_list_monitor_thread`. `pthread_create` uses `CLONE_FS` by default, so the new worker threads re-share `fs_struct` with the app-list thread.

From that point on `setns(CLONE_NEWNS)` requires `fs->users == 1` and returns `EINVAL`, breaking every subsequent `attach_app_list_namespace`. The existing one-shot `unshare(CLONE_FS)` at the top of `app_list_monitor_thread` only covers thread creation up to that point; it is undone the moment rayon spawns its pool.

This was latent on Mariner 2.0 (librsvg 2.50, no internal thread pool); the regression appeared when the system distro moved to Azure Linux 3 (librsvg 2.58 with rayon).

### Why `N` icons survive

Whichever `.desktop` entries get enumerated **before the first complex-icon app** publish successfully. The first complex SVG initialises the rayon pool; every later attach fails with `EINVAL` and those apps never make it to the Start menu. `readdir` order varies, which is why different machines see different surviving icons.

## Reproduction

Stock 2.7.3 system distro, fresh user distro, install (in this order) flat-icon apps then a complex-icon app. All flat-icon apps publish OK; the first attach after the complex-icon app is processed fails with EINVAL, and the cascade follows.

```bash
# These all publish fine - flat scalable icons stay on librsvg's C path:
sudo apt install -y gnome-calculator gnome-text-editor gnome-clocks \
                    gnome-system-monitor baobab evince file-roller eog \
                    seahorse simple-scan gnome-disk-utility gnome-weather

# This triggers it - audacity's SVG hits librsvg's parallel path:
sudo apt install -y audacity

# Every install after this point fails to publish:
sudo apt install -y gimp inkscape vlc
```

## Fix

Call `unshare(CLONE_FS)` inside `attach_app_list_namespace` before every `setns`. `unshare` only detaches the calling thread, so existing rayon/glib/etc. worker threads keep sharing the prior `fs_struct` and this thread gets a fresh one with refcount 1.

Cheap (one syscall per attach) and robust against any future thread-spawning library on this code path - librsvg is just the trigger we tripped over today.