### PR TITLE
rdp-backend: preserve active clipboard transfer fd

### DIFF
--- a/libweston/backend-rdp/meson.build
+++ b/libweston/backend-rdp/meson.build
@@ -66,6 +66,7 @@ srcs_rdp = [
         'rdp.c',
         'rdpdisp.c',
         'rdpclip.c',
+        'rdpclip-fd.c',
         'rdprail.c',
         'rdputil.c',
 ]

--- a/libweston/backend-rdp/rdpclip-fd.c
+++ b/libweston/backend-rdp/rdpclip-fd.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 huyuliang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <unistd.h>
+
+#include "rdpclip-fd.h"
+
+int
+rdp_clipboard_take_fd(int current_fd, int incoming_fd)
+{
+	if (current_fd != -1) {
+		close(incoming_fd);
+		return current_fd;
+	}
+
+	return incoming_fd;
+}

--- a/libweston/backend-rdp/rdpclip-fd.h
+++ b/libweston/backend-rdp/rdpclip-fd.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 huyuliang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef RDPCLIP_FD_H
+#define RDPCLIP_FD_H
+
+/* Takes ownership of incoming_fd. Preserve current_fd when it is active and
+ * close incoming_fd; otherwise return incoming_fd. */
+int
+rdp_clipboard_take_fd(int current_fd, int incoming_fd);
+
+#endif /* RDPCLIP_FD_H */

--- a/libweston/backend-rdp/rdpclip.c
+++ b/libweston/backend-rdp/rdpclip.c
@@ -36,6 +36,7 @@
 #include <stdio.h>
 
 #include "rdp.h"
+#include "rdpclip-fd.h"
 
 #include "libweston-internal.h"
 
@@ -105,7 +106,6 @@ enum rdp_clipboard_data_source_state {
 	RDP_CLIPBOARD_SOURCE_TRANSFERRED, /* completed transfering data to consumer */
 	RDP_CLIPBOARD_SOURCE_CANCEL_PENDING, /* data transfer cancel requested */
 	RDP_CLIPBOARD_SOURCE_CANCELED, /* data transfer canceled */
-	RDP_CLIPBOARD_SOURCE_RETRY, /* retry later */
 	RDP_CLIPBOARD_SOURCE_FAILED, /* failure occured */
 };
 
@@ -162,8 +162,6 @@ clipboard_data_source_state_to_string(struct rdp_clipboard_data_source *source)
 		return "cancel pending";
 	case RDP_CLIPBOARD_SOURCE_CANCELED:
 		return "canceled";
-	case RDP_CLIPBOARD_SOURCE_RETRY:
-		return "retry";
 	case RDP_CLIPBOARD_SOURCE_FAILED:
 		return "failed";
 	}
@@ -1108,9 +1106,11 @@ clipboard_data_source_send(struct weston_data_source *base,
 			   clipboard_data_source_state_to_string(ctx->clipboard_inflight_client_data_source),
 			   ctx->clipboard_inflight_client_data_source->data_source_fd);
 		if (source == ctx->clipboard_inflight_client_data_source) {
-			/* when new source and previous source is same, update fd with new one and retry */
-			source->state = RDP_CLIPBOARD_SOURCE_RETRY;
-			ctx->clipboard_inflight_client_data_source->data_source_fd = fd;
+			/* Keep the active transfer intact. The requester may retry
+			 * after receiving EOF on the new fd. */
+			assert(source->data_source_fd != -1);
+			source->data_source_fd =
+				rdp_clipboard_take_fd(source->data_source_fd, fd);
 			return;
 		} else {
 			source->state = RDP_CLIPBOARD_SOURCE_FAILED;
@@ -1130,7 +1130,9 @@ clipboard_data_source_send(struct weston_data_source *base,
 	    source->client_format_id_table[index]) {	/* check supported by current data source from client */
 		ctx->clipboard_inflight_client_data_source = source;
 		source->refcount++; /* reference while request inflight. */
-		source->data_source_fd = fd;
+		assert(source->data_source_fd == -1);
+		source->data_source_fd =
+			rdp_clipboard_take_fd(source->data_source_fd, fd);
 		assert(source->inflight_write_count == 0);
 		assert(source->inflight_data_to_write == NULL);
 		assert(source->inflight_data_size == 0);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -193,6 +193,11 @@ tests = [
 tests_standalone = [
 	['config-parser', [], [ dep_zucmain ]],
 	['matrix', [], [ dep_libm, dep_matrix_c ]],
+	[
+		'rdpclip-fd',
+		['../libweston/backend-rdp/rdpclip-fd.c'],
+		[ dep_zucmain ],
+	],
 	['timespec', [], [ dep_zucmain ]],
 	['zuc',
 		[

--- a/tests/rdpclip-fd-test.c
+++ b/tests/rdpclip-fd-test.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 huyuliang
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "libweston/backend-rdp/rdpclip-fd.h"
+#include "zunitc/zunitc.h"
+
+ZUC_TEST(rdpclip_fd_test, accepts_fd_without_active_transfer)
+{
+	int pipefd[2];
+	int active_fd;
+
+	ZUC_ASSERT_EQ(0, pipe(pipefd));
+
+	active_fd = rdp_clipboard_take_fd(-1, pipefd[1]);
+
+	ZUC_ASSERT_EQ(pipefd[1], active_fd);
+	ZUC_ASSERT_NE(-1, fcntl(active_fd, F_GETFD));
+
+	close(active_fd);
+	close(pipefd[0]);
+}
+
+ZUC_TEST(rdpclip_fd_test, preserves_active_fd_and_closes_incoming_fd)
+{
+	int active_pipefd[2];
+	int incoming_pipefd[2];
+	int active_fd;
+
+	ZUC_ASSERT_EQ(0, pipe(active_pipefd));
+	ZUC_ASSERT_EQ(0, pipe(incoming_pipefd));
+
+	active_fd = rdp_clipboard_take_fd(active_pipefd[1],
+					  incoming_pipefd[1]);
+
+	ZUC_ASSERT_EQ(active_pipefd[1], active_fd);
+	ZUC_ASSERT_NE(-1, fcntl(active_fd, F_GETFD));
+	errno = 0;
+	ZUC_ASSERT_EQ(-1, fcntl(incoming_pipefd[1], F_GETFD));
+	ZUC_ASSERT_EQ(EBADF, errno);
+
+	close(active_fd);
+	close(active_pipefd[0]);
+	close(incoming_pipefd[0]);
+}


### PR DESCRIPTION
## Problem

When the same RDP clipboard data source is requested again while a transfer
is active, `clipboard_data_source_send()` replaced `data_source_fd` without
updating `transfer_event_source`. The registered callback still carried the
old fd, so `clipboard_data_source_write()` aborted when it checked that the
callback fd matched `source->data_source_fd`.

This is the crash reported in microsoft/wslg#1407.

## Fix

Keep the active transfer, its fd, and its event source intact. Close the new
request pipe so the requester observes EOF and can retry after the active
transfer completes.

The fd ownership rule is isolated in a backend-private helper used both when a
transfer starts and when a repeated request arrives. Also remove
`RDP_CLIPBOARD_SOURCE_RETRY`, which had no reader and did not schedule an
actual retry.

## Tests

- Added a standalone `rdpclip-fd` test that verifies:
  - the first incoming fd is accepted and remains open;
  - a repeated incoming fd is closed with `EBADF`;
  - the active fd remains open and unchanged.
- The implementation commit builds from a clean Meson build directory before
  the test commit is applied.
- The final tree completes the configured default build, including
  `rdp-backend.so`.
- `meson test -C build-verify rdpclip-fd --print-errorlogs`: 1/1 passed.
- The same test passes under ASan+UBSan with no reports.
- `git -c core.whitespace=cr-at-eol diff --check upstream/working...HEAD`
  passes. The option accounts for the existing CRLF line endings in
  `rdpclip.c`.
- Both commits have module prefixes, wrapped explanatory bodies, and
  `Signed-off-by` lines using the GitHub account email.

The full compositor suite was also attempted in the build container. Ten
independent tests passed, while 17 tests that launch the compositor timed out
inside their first fixture. They produced no assertion or sanitizer report.
The new standalone test is not affected by that harness limitation.

The equivalent control-flow change was previously applied as a binary hot
patch to WSLg 1.0.73.2 on WSL 2.7.10.0. WSLg restarted successfully, and the
new Weston logs contained no assertion, `SIGABRT`, or core dump.