### PR TITLE
rdp-backend: Fix Belgian (Period) variant forcing fallback to us layout

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -987,7 +987,7 @@ struct rdp_to_xkb_keyboard_layout rdp_keyboards[] = {
 	{KBD_UNITED_KINGDOM, "gb", 0},
 	{KBD_LATIN_AMERICAN, "latam", 0},
 	{KBD_BELGIAN_FRENCH, "be", 0},
-	{KBD_BELGIAN_PERIOD, "be", "oss_sundeadkeys"},
+	{KBD_BELGIAN_PERIOD, "be", 0}, // variant is changed to 0 from "oss_sundeadkeys".
 	{KBD_PORTUGUESE, "pt", 0},
 	{KBD_SERBIAN_LATIN, "rs", 0},
 	{KBD_AZERI_CYRILLIC, "az", "cyrillic"},


### PR DESCRIPTION
I made this PR because i just stumbled on a regression i don't know since when that was changed, but the last time i had to do stuff for a GUI app in linux after i had set the keyboard layout to belgian inside of my wsl distro it was all fine
now i noticed it was putting me back to us, i eventually found the workaround of using another keyboard in windows and switching, but was still annoyed so i dug deeper and eventually ended up finding [this code](https://github.com/microsoft/weston-mirror/blob/working/libweston/backend-rdp/rdp.c#L862-L1053)
after that i did a little bit of debugging and found this
```shell
┌──(root㉿DESKTOP-LSGK6EL)-[~]
└─# cat /mnt/wslg/weston.log | grep -i xkb
[01:06:54.597] convert_rdp_keyboard_to_xkb_rule_names: matching model=pc105 layout=be variant=oss_sundeadkeys options=(null)
┌──(root㉿DESKTOP-LSGK6EL)-[~]
└─# cat /mnt/wslg/stderr.log
… (truncated)
xkbcommon: ERROR: [XKB-661] Couldn't process include statement for 'be(oss_sundeadkeys)'
xkbcommon: ERROR: [XKB-769] Abandoning symbols file "(unnamed)"
xkbcommon: ERROR: Failed to compile xkb_symbols
xkbcommon: ERROR: Failed to compile keymap
The XKEYBOARD keymap compiler (xkbcomp) reports:
> Warning:          Unsupported maximum keycode 708, clipping.
>                   X11 cannot support keycodes above 255.
Errors from xkbcomp are not fatal to the X server
… (truncated)
```
even if this isn't a perfect fix (altho from my tests it seems to be), it would be nice to merge quickly as having be instead of us for the users of this layout is way more appropriate

i also have a question, but why automatically isn't the fallback in case of a variant being used set to the same layout but without variant and then finally to us, this to me seems like a better idea (altho not the point of this pr, but could be a change in another PR, but please merge quickly because this bug is really annoying when using WSL for development)