### PR TITLE
Fix repeated cleanup after activation failure

### DIFF
--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -1258,10 +1258,14 @@ xf_peer_activate(freerdp_peer* client)
 error_exit:
 
 	rdp_clipboard_destroy(peerCtx);
-	if (settings->AudioPlayback && peerCtx->audio_out_private)
+	if (settings->AudioPlayback && peerCtx->audio_out_private) {
 		b->audio_out_teardown(peerCtx->audio_out_private);
-	if (settings->AudioCapture && peerCtx->audio_in_private)
+		peerCtx->audio_out_private = NULL;
+	}
+	if (settings->AudioCapture && peerCtx->audio_in_private) {
 		b->audio_in_teardown(peerCtx->audio_in_private);
+		peerCtx->audio_in_private = NULL;
+	}
 	rdp_rail_peer_context_free(client, peerCtx);
 	rdp_drdynvc_destroy(peerCtx);
 

--- a/libweston/backend-rdp/rdprail.c
+++ b/libweston/backend-rdp/rdprail.c
@@ -3998,6 +3998,7 @@ rdp_rail_peer_context_free(freerdp_peer *client, RdpPeerContext *context)
 		context->applist_server_context->Close(context->applist_server_context);
 		assert(b->rdpapplist_server_context_free);
 		b->rdpapplist_server_context_free(context->applist_server_context);
+		context->applist_server_context = NULL;
 	}
 #endif /* HAVE_FREERDP_RDPAPPLIST_H */
 
@@ -4010,22 +4011,26 @@ rdp_rail_peer_context_free(freerdp_peer *client, RdpPeerContext *context)
 		redir_ctx->Close(redir_ctx);
 		assert(b->gfxredir_server_context_free);
 		b->gfxredir_server_context_free(redir_ctx);
+		context->gfxredir_server_context = NULL;
 	}
 #endif /* HAVE_FREERDP_GFXREDIR_H */
 
 	if (gfx_ctx) {
 		gfx_ctx->Close(gfx_ctx);
 		rdpgfx_server_context_free(gfx_ctx);
+		context->rail_grfx_server_context = NULL;
 	}
 
 	if (disp_ctx) {
 		disp_ctx->Close(disp_ctx);
 		disp_server_context_free(disp_ctx);
+		context->disp_server_context = NULL;
 	}
 
 	if (rail_ctx) {
 		rail_ctx->Stop(rail_ctx);
 		rail_server_context_free(rail_ctx);
+		context->rail_server_context = NULL;
 	}
 
 	if (context->clientExec_destroy_listener.notify) {
@@ -4062,7 +4067,6 @@ rdp_drdynvc_init(freerdp_peer *client)
 	/* Open Dynamic virtual channel */
 	vc_ctx = drdynvc_server_context_new(peer_ctx->vcm);
 
-	peer_ctx->drdynvc_server_context = drdynvc_server_context_new(peer_ctx->vcm);
 	if (!vc_ctx)
 		return false;
 	if (vc_ctx->Start(vc_ctx) != CHANNEL_RC_OK) {
@@ -4099,6 +4103,7 @@ rdp_drdynvc_destroy(RdpPeerContext *context)
 	if (vc_ctx) {
 		vc_ctx->Stop(vc_ctx);
 		drdynvc_server_context_free(vc_ctx);
+		context->drdynvc_server_context = NULL;
 	}
 }
 

--- a/libweston/backend-rdp/rdputil.c
+++ b/libweston/backend-rdp/rdputil.c
@@ -256,6 +256,9 @@ rdp_id_manager_init(struct rdp_backend *rdp_backend, struct rdp_id_manager *id_m
 void
 rdp_id_manager_free(struct rdp_id_manager *id_manager)
 {
+	if (!id_manager->rdp_backend)
+		return;
+
 	assert_compositor_thread(id_manager->rdp_backend);
 
 	if (id_manager->id_used != 0)
@@ -307,10 +310,10 @@ rdp_id_manager_lookup(struct rdp_id_manager *id_manager, UINT32 id)
 void
 rdp_id_manager_for_each(struct rdp_id_manager *id_manager, hash_table_iterator_func_t func, void *data)
 {
-	assert_compositor_thread(id_manager->rdp_backend);
-
 	if (!id_manager->hash_table)
 		return;
+
+	assert_compositor_thread(id_manager->rdp_backend);
 
 	hash_table_for_each(id_manager->hash_table, func, data);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -203,6 +203,21 @@ tests_standalone = [
 	],
 ]
 
+if get_option('backend-rdp')
+	tests_standalone += [[
+		'rdp-teardown',
+		[],
+		deps_rdp + [ dep_zucmain ],
+		plugin_rdp.extract_objects(
+			'hash.c',
+			'rdpdisp.c',
+			'rdpclip.c',
+			'rdprail.c',
+			'rdputil.c',
+		),
+	]]
+endif
+
 if get_option('xwayland')
 	d = dependency('x11', required: false)
 	if not d.found()
@@ -322,6 +337,7 @@ foreach t : tests_standalone
 		build_by_default: true,
 		include_directories: common_inc,
 		dependencies: deps_t,
+		objects: t.length() > 3 ? t[3] : [],
 		install: false,
 	)
 

--- a/tests/rdp-teardown-test.c
+++ b/tests/rdp-teardown-test.c
@@ -1,0 +1,37 @@
+#include "config.h"
+
+#include "zunitc/zunitc.h"
+
+#include "../libweston/backend-rdp/rdp.c"
+
+ZUC_TEST(rdp_teardown, activation_error_cleanup)
+{
+	struct weston_compositor compositor = { 0 };
+	struct weston_rdprail_shell_api shell_api = { 0 };
+	struct rdp_backend backend = { 0 };
+	RdpPeerContext context = { 0 };
+	rdpSettings settings = { 0 };
+	freerdp_peer peer = { 0 };
+
+	compositor.state = WESTON_COMPOSITOR_SLEEPING;
+	backend.compositor = &compositor;
+	backend.compositor_tid = rdp_get_tid();
+	backend.rdprail_shell_api = &shell_api;
+	backend.rdp_peer = &peer;
+	context.rdpBackend = &backend;
+	context._p.settings = &settings;
+	peer.context = (rdpContext *)&context;
+	settings.SurfaceCommandsEnabled = TRUE;
+	settings.RemoteApplicationMode = TRUE;
+	settings.HiDefRemoteApp = TRUE;
+	settings.DesktopWidth = 800;
+	settings.DesktopHeight = 600;
+	ZUC_ASSERT_TRUE(rdp_peer_context_new(&peer, &context));
+	wl_list_init(&context.item.link);
+	ZUC_ASSERT_EQ(0, pthread_mutex_init(&context.loop_task_list_mutex, NULL));
+	ZUC_ASSERT_TRUE(rdp_rail_peer_init(&peer, &context));
+
+	ZUC_ASSERT_FALSE(xf_peer_activate(&peer));
+	rdp_peer_context_free(&peer, &context);
+	ZUC_ASSERT_FALSE(backend.rdp_peer);
+}


### PR DESCRIPTION
RDP activation failures, such as a channel handshake timeout, can trigger cleanup twice and crash Weston, disconnecting GUI apps. Reported in https://github.com/microsoft/WSL/issues/41552.

This PR makes ID-manager cleanup safe to repeat, clears freed channel/audio pointers, and removes a duplicate dynamic-channel allocation.

This PR also adds one regression test to ensure repeated cleanup after an RDP activation failure does not crash Weston.