### PR TITLE
Build against FreeRDP 3 / Debian 13 (trixie)

### DIFF
--- a/compositor/rdpaudioin.c
+++ b/compositor/rdpaudioin.c
@@ -41,6 +41,35 @@
 #include "rdpaudio.h"
 #include <libweston/libweston.h>
 #include <shared/xalloc.h>
+#include <freerdp/version.h>
+
+/*
+ * FreeRDP 3 replaced the high level audin server API (SelectFormat /
+ * ReceiveSamples / Opening / OpenResult and the server_formats,
+ * frames_per_packet, dst_format fields) with a raw SNDIN_* PDU interface.
+ * That port has not been done yet, so microphone redirection is compiled out
+ * against FreeRDP 3. Everything else (audio output, RAIL, clipboard) is
+ * unaffected.
+ */
+#if FREERDP_VERSION_MAJOR >= 3
+
+void *
+rdp_audio_in_init(struct weston_compositor *c, HANDLE vcm)
+{
+	(void)c;
+	(void)vcm;
+	weston_log("RDPAudioIn - not supported against FreeRDP 3, audio input disabled.\n");
+	return NULL;
+}
+
+void
+rdp_audio_in_destroy(void *audio_in_private)
+{
+	(void)audio_in_private;
+}
+
+#else
+
 
 static AUDIO_FORMAT rdp_audioin_supported_audio_formats[] = {
 		{ WAVE_FORMAT_PCM, 1, 44100, 88200, 2, 16, 0, NULL },
@@ -578,3 +607,5 @@ rdp_audio_in_destroy(void *audio_in_private)
 	}
 	free(priv);
 }
+
+#endif /* FREERDP_VERSION_MAJOR >= 3 */

--- a/libweston/backend-rdp/rdp.c
+++ b/libweston/backend-rdp/rdp.c
@@ -52,6 +52,11 @@
 #include <winpr/ssl.h>
 #endif
 
+#if FREERDP_VERSION_MAJOR >= 3
+#include <freerdp/crypto/certificate.h>
+#include <freerdp/crypto/privatekey.h>
+#endif
+
 #include "shared/timespec-util.h"
 #include <libweston/libweston.h>
 #include <libweston/backend-rdp.h>
@@ -736,9 +741,17 @@ rdp_peer_context_new(freerdp_peer* client, RdpPeerContext* context)
 	if (!context->rfx_context)
 		return FALSE;
 
+#if FREERDP_VERSION_MAJOR >= 3
+	/* RFX_CONTEXT is an opaque type since FreeRDP 3; use the accessors. */
+	rfx_context_set_mode(context->rfx_context, RLGR3);
+	rfx_context_reset(context->rfx_context,
+			  client->context->settings->DesktopWidth,
+			  client->context->settings->DesktopHeight);
+#else
 	context->rfx_context->mode = RLGR3;
 	context->rfx_context->width = client->context->settings->DesktopWidth;
 	context->rfx_context->height = client->context->settings->DesktopHeight;
+#endif
 	rfx_context_set_pixel_format(context->rfx_context, DEFAULT_PIXEL_FORMAT);
 
 	context->nsc_context = nsc_context_new();
@@ -1657,7 +1670,11 @@ xf_input_keyboard_event(rdpInput *input, UINT16 flags, UINT16 code)
 			if (flags & KBD_FLAGS_EXTENDED)
 				vk_code |= KBDEXT;
 
+#if FREERDP_VERSION_MAJOR >= 3
+		scan_code = GetKeycodeFromVirtualKeyCode(vk_code, WINPR_KEYCODE_TYPE_EVDEV);
+#else
 		scan_code = GetKeycodeFromVirtualKeyCode(vk_code, KEYCODE_TYPE_EVDEV);
+#endif
 		/*weston_log("code=%x ext=%d vk_code=%x scan_code=%x\n", code, (flags & KBD_FLAGS_EXTENDED) ? 1 : 0,
 				vk_code, scan_code);*/
 
@@ -1826,6 +1843,65 @@ rdp_peer_init(freerdp_peer *client, struct rdp_backend *b)
 
 	settings = client->context->settings;
 	/* configure security settings */
+#if FREERDP_VERSION_MAJOR >= 3
+	/*
+	 * FreeRDP 3 dropped the *File / *Content string settings in favour of
+	 * rdpPrivateKey / rdpCertificate objects. freerdp_settings_set_pointer_len()
+	 * takes ownership of the object we hand over.
+	 */
+	if (b->rdp_key) {
+		rdpPrivateKey *key = freerdp_key_new_from_file(b->rdp_key);
+
+		if (!key) {
+			rdp_debug_error(b, "failed to load RDP key from %s\n", b->rdp_key);
+			goto error_initialize;
+		}
+		if (!freerdp_settings_set_pointer_len(settings,
+						      FreeRDP_RdpServerRsaKey,
+						      key, 1)) {
+			freerdp_key_free(key);
+			rdp_debug_error(b, "failed to set RDP server RSA key\n");
+			goto error_initialize;
+		}
+	}
+	if (is_tls_enabled(b)) {
+		rdpPrivateKey *tls_key;
+		rdpCertificate *tls_cert;
+
+		if (using_session_tls(b)) {
+			tls_cert = freerdp_certificate_new_from_pem(b->server_cert_content);
+			tls_key = freerdp_key_new_from_pem(b->server_key_content);
+		} else {
+			tls_cert = freerdp_certificate_new_from_file(b->server_cert);
+			tls_key = freerdp_key_new_from_file(b->server_key);
+		}
+		if (!tls_cert || !tls_key) {
+			if (tls_cert)
+				freerdp_certificate_free(tls_cert);
+			if (tls_key)
+				freerdp_key_free(tls_key);
+			rdp_debug_error(b, "failed to load TLS certificate/key\n");
+			goto error_initialize;
+		}
+		if (!freerdp_settings_set_pointer_len(settings,
+						      FreeRDP_RdpServerCertificate,
+						      tls_cert, 1)) {
+			freerdp_certificate_free(tls_cert);
+			freerdp_key_free(tls_key);
+			rdp_debug_error(b, "failed to set TLS certificate\n");
+			goto error_initialize;
+		}
+		if (!freerdp_settings_set_pointer_len(settings,
+						      FreeRDP_RdpServerRsaKey,
+						      tls_key, 1)) {
+			freerdp_key_free(tls_key);
+			rdp_debug_error(b, "failed to set TLS private key\n");
+			goto error_initialize;
+		}
+	} else {
+		settings->TlsSecurity = FALSE;
+	}
+#else
 	if (b->rdp_key)
 		settings->RdpKeyFile = strdup(b->rdp_key);
 	if (is_tls_enabled(b)) {
@@ -1839,6 +1915,7 @@ rdp_peer_init(freerdp_peer *client, struct rdp_backend *b)
 	} else {
 		settings->TlsSecurity = FALSE;
 	}
+#endif
 	settings->NlaSecurity = FALSE;
 
 	if (!client->Initialize(client)) {

--- a/libweston/backend-rdp/rdpclip.c
+++ b/libweston/backend-rdp/rdpclip.c
@@ -37,6 +37,56 @@
 
 #include "rdp.h"
 
+/*
+ * FreeRDP 3 moved the shared CLIPRDR message header fields (msgType, msgFlags,
+ * dataLen) into a nested "common" member. Keep both APIs buildable.
+ */
+#if FREERDP_VERSION_MAJOR >= 3
+#define CLIPRDR_COMMON common.
+#else
+#define CLIPRDR_COMMON
+#endif
+
+/*
+ * WinPR 3 deprecated MultiByteToWideChar()/WideCharToMultiByte() and no longer
+ * exports them. Map the two call shapes we use onto the replacement API.
+ * Return value semantics (0 on error, otherwise number of characters/bytes,
+ * including the NUL when cbMultiByte/cchWideChar covers it) are preserved.
+ */
+#if FREERDP_VERSION_MAJOR >= 3
+static inline int
+weston_MultiByteToWideChar(UINT cp, DWORD flags, LPCSTR mb, int cbMultiByte,
+			   LPWSTR wc, int cchWideChar)
+{
+	SSIZE_T rc;
+
+	(void)cp;
+	(void)flags;
+	rc = ConvertUtf8NToWChar(mb, (size_t)cbMultiByte, wc,
+				 (size_t)(wc ? cchWideChar : 0));
+	return rc < 0 ? 0 : (int)rc;
+}
+
+static inline int
+weston_WideCharToMultiByte(UINT cp, DWORD flags, LPCWSTR wc, int cchWideChar,
+			   LPSTR mb, int cbMultiByte, LPCSTR def, LPBOOL used)
+{
+	SSIZE_T rc;
+
+	(void)cp;
+	(void)flags;
+	(void)def;
+	(void)used;
+	rc = ConvertWCharNToUtf8(wc, (size_t)cchWideChar, mb,
+				 (size_t)(mb ? cbMultiByte : 0));
+	return rc < 0 ? 0 : (int)rc;
+}
+
+#define MultiByteToWideChar weston_MultiByteToWideChar
+#define WideCharToMultiByte weston_WideCharToMultiByte
+#endif
+
+
 #include "libweston-internal.h"
 
 /* From MSDN, RegisterClipboardFormat API.
@@ -791,9 +841,9 @@ clipboard_client_send_format_data_response(RdpPeerContext *ctx, struct rdp_clipb
 			    clipboard_supported_formats[source->format_index].mime_type,
 			    source->processed_data_size);
 
-	formatDataResponse.msgType = CB_FORMAT_DATA_RESPONSE;
-	formatDataResponse.msgFlags = CB_RESPONSE_OK;
-	formatDataResponse.dataLen = source->processed_data_size;
+	formatDataResponse.CLIPRDR_COMMON msgType = CB_FORMAT_DATA_RESPONSE;
+	formatDataResponse.CLIPRDR_COMMON msgFlags = CB_RESPONSE_OK;
+	formatDataResponse.CLIPRDR_COMMON dataLen = source->processed_data_size;
 	formatDataResponse.requestedFormatData = source->processed_data_start;
 	ctx->clipboard_server_context->ServerFormatDataResponse(ctx->clipboard_server_context, &formatDataResponse);
 	/* if here failed to send response, what can we do ? */
@@ -815,9 +865,9 @@ clipboard_client_send_format_data_response_fail(RdpPeerContext *ctx, struct rdp_
 		source->data_response_fail_count++;
 	}
 
-	formatDataResponse.msgType = CB_FORMAT_DATA_RESPONSE;
-	formatDataResponse.msgFlags = CB_RESPONSE_FAIL;
-	formatDataResponse.dataLen = 0;
+	formatDataResponse.CLIPRDR_COMMON msgType = CB_FORMAT_DATA_RESPONSE;
+	formatDataResponse.CLIPRDR_COMMON msgFlags = CB_RESPONSE_FAIL;
+	formatDataResponse.CLIPRDR_COMMON dataLen = 0;
 	formatDataResponse.requestedFormatData = NULL;
 	ctx->clipboard_server_context->ServerFormatDataResponse(ctx->clipboard_server_context, &formatDataResponse);
 	/* if here failed to send response, what can we do ? */
@@ -1166,8 +1216,8 @@ clipboard_data_source_send(struct weston_data_source *base,
 			/* update requesting format property */
 			source->format_index = index;
 			/* request clipboard data from client */
-			formatDataRequest.msgType = CB_FORMAT_DATA_REQUEST;
-			formatDataRequest.dataLen = 4;
+			formatDataRequest.CLIPRDR_COMMON msgType = CB_FORMAT_DATA_REQUEST;
+			formatDataRequest.CLIPRDR_COMMON dataLen = 4;
 			formatDataRequest.requestedFormatId = source->client_format_id_table[index];
 			source->state = RDP_CLIPBOARD_SOURCE_REQUEST_DATA;
 			rdp_debug_clipboard(b, "RDP %s (%p:%s) request data \"%s\" index:%d formatId:%d %s\n",
@@ -1457,7 +1507,7 @@ clipboard_set_selection(struct wl_listener *listener, void *data)
 
 	if (num_supported_format) {
 		/* let client knows formats are available in server clipboard */
-		formatList.msgType = CB_FORMAT_LIST;
+		formatList.CLIPRDR_COMMON msgType = CB_FORMAT_LIST;
 		formatList.numFormats = num_supported_format;
 		formatList.formats = &format[0];
 		ctx->clipboard_server_context->ServerFormatList(ctx->clipboard_server_context, &formatList);
@@ -1595,9 +1645,9 @@ clipboard_client_format_list(CliprdrServerContext *context, const CLIPRDR_FORMAT
 	rdp_dispatch_task_to_display_loop(ctx, clipboard_data_source_publish, &source->task_base);
 
 fail:
-	formatListResponse.msgType = CB_FORMAT_LIST_RESPONSE;
-	formatListResponse.msgFlags = source ? CB_RESPONSE_OK : CB_RESPONSE_FAIL;
-	formatListResponse.dataLen = 0;
+	formatListResponse.CLIPRDR_COMMON msgType = CB_FORMAT_LIST_RESPONSE;
+	formatListResponse.CLIPRDR_COMMON msgFlags = source ? CB_RESPONSE_OK : CB_RESPONSE_FAIL;
+	formatListResponse.CLIPRDR_COMMON dataLen = 0;
 	if (ctx->clipboard_server_context->ServerFormatListResponse(ctx->clipboard_server_context, &formatListResponse) != 0) {
 		source->state = RDP_CLIPBOARD_SOURCE_FAILED;
 		weston_log("Client: %s (%p:%s) ServerFormatListResponse failed\n",
@@ -1623,8 +1673,8 @@ clipboard_client_format_data_response(CliprdrServerContext *context, const CLIPR
 	rdp_debug_clipboard(b, "Client: %s (%p:%s) flags:%d dataLen:%d\n",
 			    __func__, source,
 			    clipboard_data_source_state_to_string(source),
-			    formatDataResponse->msgFlags,
-			    formatDataResponse->dataLen);
+			    formatDataResponse->CLIPRDR_COMMON msgFlags,
+			    formatDataResponse->CLIPRDR_COMMON dataLen);
 
 	assert_not_compositor_thread(b);
 
@@ -1642,13 +1692,13 @@ clipboard_client_format_data_response(CliprdrServerContext *context, const CLIPR
 		return -1;
 	}
 
-	if (formatDataResponse->msgFlags == CB_RESPONSE_OK) {
+	if (formatDataResponse->CLIPRDR_COMMON msgFlags == CB_RESPONSE_OK) {
 		/* Recieved data from client, cache to data source */
-		if (wl_array_add(&source->data_contents, formatDataResponse->dataLen+1)) {
+		if (wl_array_add(&source->data_contents, formatDataResponse->CLIPRDR_COMMON dataLen+1)) {
 			memcpy(source->data_contents.data,
 			       formatDataResponse->requestedFormatData,
-			       formatDataResponse->dataLen);
-			source->data_contents.size = formatDataResponse->dataLen;
+			       formatDataResponse->CLIPRDR_COMMON dataLen);
+			source->data_contents.size = formatDataResponse->CLIPRDR_COMMON dataLen;
 			/* regardless data type, make sure it ends with NULL */
 			((char *)source->data_contents.data)[source->data_contents.size] = '\0';
 			/* data is ready, waiting to be written to destination */
@@ -1693,7 +1743,7 @@ clipboard_client_format_list_response(CliprdrServerContext *context,
 	RdpPeerContext *ctx = (RdpPeerContext *)client->context;
 	struct rdp_backend *b = ctx->rdpBackend;
 
-	rdp_debug_clipboard(b, "Client: %s msgFlags:0x%x\n", __func__, formatListResponse->msgFlags);
+	rdp_debug_clipboard(b, "Client: %s msgFlags:0x%x\n", __func__, formatListResponse->CLIPRDR_COMMON msgFlags);
 	assert_not_compositor_thread(b);
 	return 0;
 }


### PR DESCRIPTION
Debian 13 ships freerdp3 3.15. The RDP backend was written against an earlier FreeRDP 3 API and no longer compiles. Fix the three affected translation units; everything else (rdprail.c, rdpdisp.c, rdputil.c and all of rdprail-shell) builds unchanged.

libweston/backend-rdp/rdp.c:
 - RFX_CONTEXT is opaque since FreeRDP 3: use rfx_context_set_mode() and rfx_context_reset() instead of assigning ->mode/->width/->height.
 - KEYCODE_TYPE_EVDEV was renamed to WINPR_KEYCODE_TYPE_EVDEV.
 - The CertificateFile/PrivateKeyFile/RdpKeyFile/CertificateContent/ PrivateKeyContent string settings were replaced by rdpCertificate and rdpPrivateKey objects. Load them with freerdp_certificate_new_from_*() and freerdp_key_new_from_*() and hand them over via freerdp_settings_set_pointer_len(), with error handling and cleanup.

libweston/backend-rdp/rdpclip.c:
 - The shared CLIPRDR message header fields (msgType, msgFlags, dataLen) moved into a nested "common" member. Routed through a CLIPRDR_COMMON macro so the FreeRDP 2 layout keeps working.
 - MultiByteToWideChar()/WideCharToMultiByte() are deprecated and no longer exported by libwinpr3. Add inline shims on top of ConvertUtf8NToWChar()/ConvertWCharNToUtf8().

compositor/rdpaudioin.c:
 - The audin server API was redesigned around raw SNDIN_* PDUs; the old SelectFormat/ReceiveSamples/Opening/OpenResult callbacks and the server_formats/client_formats/frames_per_packet/dst_format fields are gone. That port is not done yet, so compile the implementation out against FreeRDP 3 and provide stubs. Microphone redirection is disabled; audio output, RAIL and clipboard are unaffected.

All changes are guarded by FREERDP_VERSION_MAJOR >= 3, so the FreeRDP 2 path is untouched.

Verified with a clean build against FreeRDP 3.31 (gcc 13): weston, rdp-backend.so and rdprail-shell.so all build.